### PR TITLE
feature 1034 Show GoogleMap on LatLong

### DIFF
--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditGoogleMap.g.razor
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditGoogleMap.g.razor
@@ -1,0 +1,80 @@
+﻿@using Cryptocash.Ui.Generated.Component;
+@inherits UiEditGoogleMapBase
+
+<script>
+    var oldMarker, dotNetHelper;
+    var defaultLat;
+    var defaultLng;
+    var addDefaultMarker = false;
+
+    function updateDefaultLatLong(lat, lng, defaultMarker){
+        defaultLat = lat;
+        defaultLng = lng;
+        addDefaultMarker = defaultMarker;
+    }
+
+    function initMap() {
+        const myLatlng = { lat: defaultLat, lng: defaultLng };
+        const map = new google.maps.Map(document.getElementById("map"), {
+            zoom: 4,
+            center: myLatlng,
+        });
+
+        if (addDefaultMarker == true) {
+            addDefaultMarker = false;
+            placeMarker(myLatlng);
+        }
+
+        map.addListener("click", (mapsMouseEvent) => {
+
+            placeMarker(mapsMouseEvent.latLng);        
+
+            PlaceMarkerCallbackHelpers.performPlaceMarker(mapsMouseEvent.latLng.lat(), mapsMouseEvent.latLng.lng());
+
+        });
+
+        function placeMarker(location) {
+
+            marker = new google.maps.Marker({
+                position: location,
+                map,
+                title: "",
+            });
+
+            if (oldMarker != undefined) {
+                oldMarker.setMap(null);
+            }
+            oldMarker = marker;
+            map.setCenter(location);
+
+        }
+    }  
+    
+    class PlaceMarkerCallbackHelpers {
+        static dotNetHelper;
+
+        static setDotNetHelper(value) {
+            PlaceMarkerCallbackHelpers.dotNetHelper = value;
+        }
+
+        static async performPlaceMarker(lat, long) {
+            await PlaceMarkerCallbackHelpers.dotNetHelper.invokeMethodAsync('UpdateLatlong', lat, long);
+        }
+    }
+
+    window.PlaceMarkerCallbackHelpers = PlaceMarkerCallbackHelpers;
+
+</script>   
+
+<style>
+    #map {
+        overflow: hidden;
+        background: none !important;
+        overflow: hidden;
+        padding-bottom: 56.25%;
+        position: relative;
+        height: 0;
+    }
+</style> 
+
+<div id="map"></div>

--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditGoogleMapBase.g.cs
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditGoogleMapBase.g.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.AspNetCore.Components;
+using Cryptocash.Application.Dto;
+using Cryptocash.Ui.Generated.Data.Generic;
+using MudBlazor;
+using Microsoft.JSInterop;
+using Nox.Types;
+using Cryptocash.Ui.Generated.Data.Helper;
+
+namespace Cryptocash.Ui.Generated.Component
+{
+    public class UiEditGoogleMapBase : ComponentBase
+    {
+        #nullable enable
+
+        #region Declarations
+
+        [Inject]
+        public IJSRuntime? JSRuntime { get; set; }
+
+        private DotNetObjectReference<UiEditGoogleMapBase>? dotNetHelper;
+
+        [Parameter]
+        public LatLongDto? LatLong { get; set; }
+
+        public double? CurrentLatitude { get; set; }
+
+        public double? CurrentLongitude { get; set; }
+
+        private double DefaultLatitude { get; set; } = 51.509865;
+
+        private double DefaultLongitude { get; set; } = -0.118092;
+
+        [Parameter]
+        public EventCallback<LatLongDto> LatLongChanged { get; set; }
+
+        #endregion
+
+        /// <summary>
+        /// Handles initial loading
+        /// </summary>
+        protected override void OnInitialized()
+        {
+            if (LatLong != null)
+            {
+                CurrentLatitude = LatLong.Latitude;
+                CurrentLongitude = LatLong.Longitude;
+            }
+        }
+
+        /// <summary>
+        /// Handles Javascript interactions
+        /// </summary>
+        /// <param name="firstRender"></param>
+        /// <returns></returns>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender
+                && JSRuntime != null)
+            {
+                if (LatLong != null)
+                {
+                    await JSRuntime.InvokeVoidAsync("updateDefaultLatLong", LatLong.Latitude, LatLong.Longitude, true);
+                }
+                else
+                {
+                    await JSRuntime.InvokeVoidAsync("updateDefaultLatLong", DefaultLatitude, DefaultLongitude, false);
+                }
+                await JSRuntime.InvokeVoidAsync("initMap", null);
+                dotNetHelper = DotNetObjectReference.Create(this);
+                await JSRuntime.InvokeVoidAsync("PlaceMarkerCallbackHelpers.setDotNetHelper", dotNetHelper);
+                StateHasChanged();
+            }
+        }
+
+        [JSInvokable]
+        public async void UpdateLatlong(double latitude, double longitude)
+        {
+            LatLong = new LatLongDto(latitude, longitude);
+            await LatLongChanged.InvokeAsync(LatLong);
+        }
+
+    }
+}

--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditLatLong.g.razor
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditLatLong.g.razor
@@ -24,4 +24,9 @@
     </MudItem>
 </MudGrid>
 
-
+@if (DisplayGoogleMap)
+{
+    <div style="margin-top:30px;">
+        <UiEditGoogleMap_g LatLong="LatLong" LatLongChanged="OnLatLongChanged" />
+    </div>
+}

--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditLatLongBase.g.cs
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Component/UiEditLatLongBase.g.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Cryptocash.Application.Dto;
-using Cryptocash.Ui.Generated.Data.Generic;
-using MudBlazor;
 
 namespace Cryptocash.Ui.Generated.Component
 {
@@ -15,6 +13,9 @@ namespace Cryptocash.Ui.Generated.Component
         public double? CurrentLatitude { get; set; }
 
         public double? CurrentLongitude { get; set; }
+
+        [Parameter]
+        public bool DisplayGoogleMap { get; set; } = false;
 
         [Parameter]
         public string TitleLatitude { get; set; }
@@ -76,6 +77,18 @@ namespace Cryptocash.Ui.Generated.Component
             LatLong = new LatLongDto(useLatitude, (double)CurrentLongitude);
 
             await LatLongChanged.InvokeAsync(LatLong);
+        }
+
+        protected async Task OnLatLongChanged(LatLongDto newValue)
+        {
+            if (newValue != null)
+            {
+                CurrentLatitude = newValue.Latitude;
+                CurrentLongitude = newValue.Longitude;
+                LatLong = newValue;
+
+                await LatLongChanged.InvokeAsync(LatLong);
+            }                  
         }
 
         protected string ErrorRequiredMessage(string CurrentTitle)

--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Pages/Generic/ListEntityPageBase.g.cs
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Pages/Generic/ListEntityPageBase.g.cs
@@ -92,7 +92,8 @@ namespace Cryptocash.Ui.Generated.Pages.Generic
             FullWidth = true,
             ClassBackground = "custom-dialog",
             DisableBackdropClick = true,
-            Position = DialogPosition.TopCenter
+            Position = DialogPosition.TopCenter,
+            MaxWidth = MaxWidth.Large
         };
 
         /// <summary>
@@ -103,7 +104,8 @@ namespace Cryptocash.Ui.Generated.Pages.Generic
             FullWidth = true,
             ClassBackground = "custom-dialog",
             DisableBackdropClick = true,
-            Position = DialogPosition.TopCenter
+            Position = DialogPosition.TopCenter,
+            MaxWidth = MaxWidth.Large
         };
 
         /// <summary>
@@ -190,6 +192,36 @@ namespace Cryptocash.Ui.Generated.Pages.Generic
         /// Property LandLordEntityData used to store LandLord list data in preparation for selection
         /// </summary>
         public EntityData<LandLordDto>? LandLordEntityData { get; set; }
+
+        /// <summary>
+        /// Property GoogleMapApiKey to define Api security key
+        /// </summary>
+        public string? GoogleMapApiKey { get; set; }
+
+        /// <summary>
+        /// Property GoogleMapJsUrl to define access to Google Maps Js
+        /// </summary>
+        public string? GoogleMapJsUrl
+        {
+            get
+            {
+                if (!String.IsNullOrWhiteSpace(GoogleMapApiKey))
+                {
+                    return $"https://maps.googleapis.com/maps/api/js?key={GoogleMapApiKey}&callback=initMap&v=weekly";
+                }
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Property DisplayGoogleMap to define if Google Maps can be displayed
+        /// </summary>
+        public bool DisplayGoogleMap { 
+            get
+            {
+                return !String.IsNullOrWhiteSpace(GoogleMapJsUrl);
+            } 
+        }
 
         #endregion
 

--- a/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Pages/VendingMachineList.g.razor
+++ b/samples/Cryptocash.Ui/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Pages/VendingMachineList.g.razor
@@ -120,26 +120,53 @@
                                             </MudTabPanel>
                                             <MudTabPanel Text="Location">
                                                 <MudGrid Style="margin-top:15px;">
-                                                    <MudItem xs=12>
-                                                        <UiEditLatLong_g @bind-Latlong="CurrentAddEntity.GeoLocation"
-                                                                         TitleLatitude="Latitude"
-                                                                         TitleLongitude="Longitude"
-                                                                         Format="#.########" />
-                                                    </MudItem>
-                                                    <MudItem xs=12>
-                                                        <UiEditStreetAddress_g @bind-StreetAddress="CurrentAddEntity.StreetAddress"
-                                                                               TitleStreetNumber="StreetNumber"
-                                                                               TitleAddressLine1="AddressLine1"
-                                                                               TitleAddressLine2="AddressLine2"
-                                                                               TitleRoute="Route"
-                                                                               TitleLocality="Locality"
-                                                                               TitleNeighborhood="Neighborhood"
-                                                                               TitleAdministrativeArea1="AdministrativeArea1"
-                                                                               TitleAdministrativeArea2="AdministrativeArea2"
-                                                                               TitlePostalCode="PostalCode"
-                                                                               TitleCountryId="CountryId"
-                                                                               CountrySelectionList="CountryEntityData?.EntityList" />
-                                                    </MudItem>
+                                                    @if(DisplayGoogleMap){
+                                                        <MudItem xs=12 sm=6>
+                                                            <UiEditLatLong_g @bind-Latlong="CurrentAddEntity.GeoLocation"
+                                                                             TitleLatitude="Latitude"
+                                                                             TitleLongitude="Longitude"
+                                                                             Format="#.########"
+                                                                             DisplayGoogleMap="DisplayGoogleMap" />
+                                                        </MudItem>
+                                                        <MudItem xs=12 sm=6>
+                                                            <UiEditStreetAddress_g @bind-StreetAddress="CurrentAddEntity.StreetAddress"
+                                                                                   TitleStreetNumber="StreetNumber"
+                                                                                   TitleAddressLine1="AddressLine1"
+                                                                                   TitleAddressLine2="AddressLine2"
+                                                                                   TitleRoute="Route"
+                                                                                   TitleLocality="Locality"
+                                                                                   TitleNeighborhood="Neighborhood"
+                                                                                   TitleAdministrativeArea1="AdministrativeArea1"
+                                                                                   TitleAdministrativeArea2="AdministrativeArea2"
+                                                                                   TitlePostalCode="PostalCode"
+                                                                                   TitleCountryId="CountryId"
+                                                                                   CountrySelectionList="CountryEntityData?.EntityList" />
+                                                        </MudItem>
+                                                    }
+                                                    else
+                                                    {
+                                                        <MudItem xs=12>
+                                                            <UiEditLatLong_g @bind-Latlong="CurrentAddEntity.GeoLocation"
+                                                                             TitleLatitude="Latitude"
+                                                                             TitleLongitude="Longitude"
+                                                                             Format="#.########"
+                                                                             DisplayGoogleMap="DisplayGoogleMap" />
+                                                        </MudItem>
+                                                        <MudItem xs=12>
+                                                            <UiEditStreetAddress_g @bind-StreetAddress="CurrentAddEntity.StreetAddress"
+                                                                                   TitleStreetNumber="StreetNumber"
+                                                                                   TitleAddressLine1="AddressLine1"
+                                                                                   TitleAddressLine2="AddressLine2"
+                                                                                   TitleRoute="Route"
+                                                                                   TitleLocality="Locality"
+                                                                                   TitleNeighborhood="Neighborhood"
+                                                                                   TitleAdministrativeArea1="AdministrativeArea1"
+                                                                                   TitleAdministrativeArea2="AdministrativeArea2"
+                                                                                   TitlePostalCode="PostalCode"
+                                                                                   TitleCountryId="CountryId"
+                                                                                   CountrySelectionList="CountryEntityData?.EntityList" />
+                                                        </MudItem>
+                                                    }                                                  
                                                 </MudGrid>
                                             </MudTabPanel>
                                             <MudTabPanel Text="Minimum Cash Stocks">
@@ -233,14 +260,41 @@
                                             </MudTabPanel>
                                             <MudTabPanel Text="Location">
                                                 <MudGrid Style="margin-top:15px;">
-                                                    <MudItem xs="12">
-                                                        <UiEditLatLong_g @bind-Latlong="CurrentEditEntity.GeoLocation"
-                                                                         TitleLatitude="Latitude"
-                                                                         TitleLongitude="Longitude"
-                                                                         Format="#.########" />
-                                                    </MudItem>
-                                                    <MudItem xs=12>
-                                                        <UiEditStreetAddress_g @bind-StreetAddress="CurrentEditEntity.StreetAddress"
+                                                    @if (DisplayGoogleMap)
+                                                    {
+                                                        <MudItem xs=12 sm=6>
+                                                            <UiEditLatLong_g @bind-Latlong="CurrentEditEntity.GeoLocation"
+                                                                             TitleLatitude="Latitude"
+                                                                             TitleLongitude="Longitude"
+                                                                             Format="#.########"
+                                                                             DisplayGoogleMap="DisplayGoogleMap" />
+                                                        </MudItem>
+                                                        <MudItem xs=12 sm=6>
+                                                            <UiEditStreetAddress_g @bind-StreetAddress="CurrentEditEntity.StreetAddress"
+                                                                                   TitleStreetNumber="StreetNumber"
+                                                                                   TitleAddressLine1="AddressLine1"
+                                                                                   TitleAddressLine2="AddressLine2"
+                                                                                   TitleRoute="Route"
+                                                                                   TitleLocality="Locality"
+                                                                                   TitleNeighborhood="Neighborhood"
+                                                                                   TitleAdministrativeArea1="AdministrativeArea1"
+                                                                                   TitleAdministrativeArea2="AdministrativeArea2"
+                                                                                   TitlePostalCode="PostalCode"
+                                                                                   TitleCountryId="CountryId"
+                                                                                   CountrySelectionList="CountryEntityData?.EntityList" />
+                                                        </MudItem>
+                                                    }
+                                                    else
+                                                    {
+                                                        <MudItem xs=12>
+                                                            <UiEditLatLong_g @bind-Latlong="CurrentEditEntity.GeoLocation"
+                                                                             TitleLatitude="Latitude"
+                                                                             TitleLongitude="Longitude"
+                                                                             Format="#.########"
+                                                                             DisplayGoogleMap="DisplayGoogleMap" />
+                                                        </MudItem>
+                                                        <MudItem xs=12>
+                                                            <UiEditStreetAddress_g @bind-StreetAddress="CurrentEditEntity.StreetAddress"
                                                                                TitleStreetNumber="StreetNumber"
                                                                                TitleAddressLine1="AddressLine1"
                                                                                TitleAddressLine2="AddressLine2"
@@ -252,7 +306,8 @@
                                                                                TitlePostalCode="PostalCode"
                                                                                TitleCountryId="CountryId"
                                                                                CountrySelectionList="CountryEntityData?.EntityList" />
-                                                    </MudItem>
+                                                        </MudItem>
+                                                    }
                                                 </MudGrid>
                                             </MudTabPanel>
                                         </MudTabs>
@@ -601,3 +656,8 @@ else
         border-bottom-width: 3px;
     }
 </style>
+
+@if (DisplayGoogleMap)
+{
+    <script src="@GoogleMapJsUrl" defer></script>
+}


### PR DESCRIPTION
PR for adding GoogleMap to LatLong in ADD and EDIT form for Cryptocash.Ui - this allows LatLong selection via the map instead - using javascript communicating with the blazor component

Note: to see map you need to set the ListEntityPageBase.g.GoogleMapApiKey otherwise it defaults to display off
Also note that the GoogleMap JS has to be on the VendingMachineList page rather than the EditGoogleMap component as looks like it needs to be loaded on the parent first to use it without issue.

Will discuss enhancing map with extra tickets for adding location SearchBox, Default location and auto selecting form Country based on Map LatLong selection