### PR TITLE
Allow clients apps to define errocodes and error details on api response

### DIFF
--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
@@ -57,7 +57,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
     private Cryptocash.Domain.Country ToEntity(CountryCreateDto createDto)
     {
         var entity = new Cryptocash.Domain.Country();
-        entity.Id = CountryMetadata.CreateId(createDto.Id!);
+        entity.Id = CountryMetadata.CreateId(createDto.Id);
         entity.Name = Cryptocash.Domain.CountryMetadata.CreateName(createDto.Name);
         entity.SetIfNotNull(createDto.OfficialName, (entity) => entity.OfficialName =Cryptocash.Domain.CountryMetadata.CreateOfficialName(createDto.OfficialName.NonNullValue<System.String>()));
         entity.SetIfNotNull(createDto.CountryIsoNumeric, (entity) => entity.CountryIsoNumeric =Cryptocash.Domain.CountryMetadata.CreateCountryIsoNumeric(createDto.CountryIsoNumeric.NonNullValue<System.UInt16>()));

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
@@ -57,7 +57,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
     private Cryptocash.Domain.Currency ToEntity(CurrencyCreateDto createDto)
     {
         var entity = new Cryptocash.Domain.Currency();
-        entity.Id = CurrencyMetadata.CreateId(createDto.Id!);
+        entity.Id = CurrencyMetadata.CreateId(createDto.Id);
         entity.Name = Cryptocash.Domain.CurrencyMetadata.CreateName(createDto.Name);
         entity.CurrencyIsoNumeric = Cryptocash.Domain.CurrencyMetadata.CreateCurrencyIsoNumeric(createDto.CurrencyIsoNumeric);
         entity.Symbol = Cryptocash.Domain.CurrencyMetadata.CreateSymbol(createDto.Symbol);

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/BookingsController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/BookingsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class BookingsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateBookingCommand(booking, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class BookingsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class BookingsControllerBase : ODataController
     {
         if (!ModelState.IsValid || booking is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CashStockOrdersController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CashStockOrdersController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CashStockOrdersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCashStockOrderCommand(cashStockOrder, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CashStockOrdersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CashStockOrdersControllerBase : ODataController
     {
         if (!ModelState.IsValid || cashStockOrder is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CommissionsController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CommissionsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CommissionsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCommissionCommand(commission, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CommissionsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CommissionsControllerBase : ODataController
     {
         if (!ModelState.IsValid || commission is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountriesController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountriesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCountryCommand(country, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid || country is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CurrenciesController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CurrenciesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCurrencyCommand(currency, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid || currency is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CustomersController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CustomersController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CustomersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCustomerCommand(customer, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CustomersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CustomersControllerBase : ODataController
     {
         if (!ModelState.IsValid || customer is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EmployeesController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EmployeesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class EmployeesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateEmployeeCommand(employee, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class EmployeesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class EmployeesControllerBase : ODataController
     {
         if (!ModelState.IsValid || employee is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/LandLordsController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/LandLordsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class LandLordsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateLandLordCommand(landLord, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class LandLordsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class LandLordsControllerBase : ODataController
     {
         if (!ModelState.IsValid || landLord is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/MinimumCashStocksController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/MinimumCashStocksController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class MinimumCashStocksControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateMinimumCashStockCommand(minimumCashStock, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class MinimumCashStocksControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class MinimumCashStocksControllerBase : ODataController
     {
         if (!ModelState.IsValid || minimumCashStock is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/PaymentDetailsController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/PaymentDetailsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class PaymentDetailsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreatePaymentDetailCommand(paymentDetail, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class PaymentDetailsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class PaymentDetailsControllerBase : ODataController
     {
         if (!ModelState.IsValid || paymentDetail is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/PaymentProvidersController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/PaymentProvidersController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class PaymentProvidersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreatePaymentProviderCommand(paymentProvider, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class PaymentProvidersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class PaymentProvidersControllerBase : ODataController
     {
         if (!ModelState.IsValid || paymentProvider is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TransactionsController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TransactionsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TransactionsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTransactionCommand(transaction, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TransactionsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TransactionsControllerBase : ODataController
     {
         if (!ModelState.IsValid || transaction is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/VendingMachinesController/Entity.g.cs
+++ b/samples/Cryptocash.Api/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/VendingMachinesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class VendingMachinesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateVendingMachineCommand(vendingMachine, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class VendingMachinesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class VendingMachinesControllerBase : ODataController
     {
         if (!ModelState.IsValid || vendingMachine is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.Abstractions/Exceptions/IApplicationException.cs
+++ b/src/Nox.Abstractions/Exceptions/IApplicationException.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+
+namespace Nox.Exceptions;
+
+/// <summary>
+/// Provides information that can be returned to the client in case of an exception
+/// </summary>
+public interface IApplicationException
+{
+    /// <summary>
+    /// Optional: The Status code to be returned to the client in case of an Http call.
+    /// </summary>
+    HttpStatusCode? StatusCode { get; }
+
+    /// <summary>
+    /// A short string with a brief explanation of the error to be returned to the client
+    /// Snake case is recommended
+    /// </summary>
+    string ErrorCode { get; }
+
+    /// <summary>
+    /// Optional: A complex object with more details about the error to be returned to the client
+    /// This object will be serialized to JSON
+    /// </summary>
+    object? ErrorDetails { get; }
+}

--- a/src/Nox.ClientApi.Tests/Application/CommandHandlers/CreateCountryLocalNameForCountryCommandHandler.cs
+++ b/src/Nox.ClientApi.Tests/Application/CommandHandlers/CreateCountryLocalNameForCountryCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using ClientApi.Application.Dto;
+using ClientApi.Application.Exceptions;
 
 namespace ClientApi.Application.Commands;
 
@@ -7,18 +8,30 @@ namespace ClientApi.Application.Commands;
 /// </summary>
 public partial record CreateCountryLocalNamesForCountryCommand
 {
-    public string CustomField { get; set; } = string.Empty;
+    public string AlternativeName { get; set; } = string.Empty;
 }
 
 
 internal partial class CreateCountryLocalNamesForCountryCommandHandler
 {
-    public override async Task<CountryLocalNameKeyDto?> Handle(CreateCountryLocalNamesForCountryCommand request, CancellationToken cancellationToken)
+    public override async Task<CountryLocalNameKeyDto?> Handle(
+        CreateCountryLocalNamesForCountryCommand request,
+        CancellationToken cancellationToken
+        )
     {
         /// Example how to use the custom field added to the default request
-        if(string.IsNullOrEmpty(request.CustomField))
-        { 
-            throw new Exception("CustomField should be set on the API controller that is overriding the default beahvior");
+        if (string.IsNullOrEmpty(request.AlternativeName))
+        {
+            //Example how to customize the returned status code, and error code
+            throw new CountryNameInvalid()
+            {
+                ErrorDetails = new
+                {
+                    Name = request.EntityDto.Name,
+                    NativeName = request.EntityDto.NativeName,
+                    Message = "AlternativeName is required, name and native name are not sufficient!"
+                }
+            };
         }
         return await base.Handle(request, cancellationToken);
     }

--- a/src/Nox.ClientApi.Tests/Application/Exceptions/CountryNameInvalid.cs
+++ b/src/Nox.ClientApi.Tests/Application/Exceptions/CountryNameInvalid.cs
@@ -1,0 +1,30 @@
+﻿using Nox.Exceptions;
+using System.Net;
+
+namespace ClientApi.Application.Exceptions
+{
+    [Serializable]
+    public class CountryNameInvalid : Exception, IApplicationException
+    {
+        public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+        public string ErrorCode => "invalid_countryname";
+
+        public required object ErrorDetails { get; set; }
+
+        public CountryNameInvalid()
+        {
+        }
+
+        public CountryNameInvalid(string message)
+            : base(message)
+        {
+        }
+
+        public CountryNameInvalid(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+       
+    }
+}

--- a/src/Nox.ClientApi.Tests/Controllers/CountriesController.cs
+++ b/src/Nox.ClientApi.Tests/Controllers/CountriesController.cs
@@ -39,7 +39,7 @@ public partial class CountriesController
         }
 
         var etag = Request.GetDecodedEtagHeader();
-        var createdKey = await _mediator.Send(new CreateCountryLocalNamesForCountryCommand(new CountryKeyDto(key), countryLocalName, etag) { CustomField = "Example"});
+        var createdKey = await _mediator.Send(new CreateCountryLocalNamesForCountryCommand(new CountryKeyDto(key), countryLocalName, etag) { AlternativeName = "Example"});
         if (createdKey == null)
         {
             return NotFound();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryBarCodeFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryBarCodeFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class CountryBarCodeFactoryBase : IEntityFactory<CountryBarCod
 
     public virtual CountryBarCodeEntity CreateEntity(CountryBarCodeUpsertDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CountryBarCodeEntity entity, CountryBarCodeUpsertDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
@@ -41,7 +41,14 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 
     public virtual CountryEntity CreateEntity(CountryCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CountryEntity entity, CountryUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryLocalNameFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryLocalNameFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class CountryLocalNameFactoryBase : IEntityFactory<CountryLoca
 
     public virtual CountryLocalNameEntity CreateEntity(CountryLocalNameUpsertDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CountryLocalNameEntity entity, CountryLocalNameUpsertDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryQualityOfLifeIndexFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryQualityOfLifeIndexFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class CountryQualityOfLifeIndexFactoryBase : IEntityFactory<Co
 
     public virtual CountryQualityOfLifeIndexEntity CreateEntity(CountryQualityOfLifeIndexCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CountryQualityOfLifeIndexEntity entity, CountryQualityOfLifeIndexUpdateDto updateDto, Nox.Types.CultureCode cultureCode)
@@ -51,7 +58,7 @@ internal abstract class CountryQualityOfLifeIndexFactoryBase : IEntityFactory<Co
     private ClientApi.Domain.CountryQualityOfLifeIndex ToEntity(CountryQualityOfLifeIndexCreateDto createDto)
     {
         var entity = new ClientApi.Domain.CountryQualityOfLifeIndex();
-        entity.CountryId = CountryQualityOfLifeIndexMetadata.CreateCountryId(createDto.CountryId!);
+        entity.CountryId = CountryQualityOfLifeIndexMetadata.CreateCountryId(createDto.CountryId);
         entity.IndexRating = ClientApi.Domain.CountryQualityOfLifeIndexMetadata.CreateIndexRating(createDto.IndexRating);
         return entity;
     }

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
 
     public virtual CurrencyEntity CreateEntity(CurrencyCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CurrencyEntity entity, CurrencyUpdateDto updateDto, Nox.Types.CultureCode cultureCode)
@@ -51,7 +58,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
     private ClientApi.Domain.Currency ToEntity(CurrencyCreateDto createDto)
     {
         var entity = new ClientApi.Domain.Currency();
-        entity.Id = CurrencyMetadata.CreateId(createDto.Id!);
+        entity.Id = CurrencyMetadata.CreateId(createDto.Id);
         entity.SetIfNotNull(createDto.Name, (entity) => entity.Name =ClientApi.Domain.CurrencyMetadata.CreateName(createDto.Name.NonNullValue<System.String>()));
         entity.SetIfNotNull(createDto.Symbol, (entity) => entity.Symbol =ClientApi.Domain.CurrencyMetadata.CreateSymbol(createDto.Symbol.NonNullValue<System.String>()));
         return entity;

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EmailAddressFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EmailAddressFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class EmailAddressFactoryBase : IEntityFactory<EmailAddressEnt
 
     public virtual EmailAddressEntity CreateEntity(EmailAddressUpsertDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(EmailAddressEntity entity, EmailAddressUpsertDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/RatingProgramFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/RatingProgramFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class RatingProgramFactoryBase : IEntityFactory<RatingProgramE
 
     public virtual RatingProgramEntity CreateEntity(RatingProgramCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(RatingProgramEntity entity, RatingProgramUpdateDto updateDto, Nox.Types.CultureCode cultureCode)
@@ -51,7 +58,7 @@ internal abstract class RatingProgramFactoryBase : IEntityFactory<RatingProgramE
     private ClientApi.Domain.RatingProgram ToEntity(RatingProgramCreateDto createDto)
     {
         var entity = new ClientApi.Domain.RatingProgram();
-        entity.StoreId = RatingProgramMetadata.CreateStoreId(createDto.StoreId!);
+        entity.StoreId = RatingProgramMetadata.CreateStoreId(createDto.StoreId);
         entity.SetIfNotNull(createDto.Name, (entity) => entity.Name =ClientApi.Domain.RatingProgramMetadata.CreateName(createDto.Name.NonNullValue<System.String>()));
         return entity;
     }

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreFactory.g.cs
@@ -38,7 +38,14 @@ internal abstract class StoreFactoryBase : IEntityFactory<StoreEntity, StoreCrea
 
     public virtual StoreEntity CreateEntity(StoreCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(StoreEntity entity, StoreUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreLicenseFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreLicenseFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class StoreLicenseFactoryBase : IEntityFactory<StoreLicenseEnt
 
     public virtual StoreLicenseEntity CreateEntity(StoreLicenseCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(StoreLicenseEntity entity, StoreLicenseUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreOwnerFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreOwnerFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class StoreOwnerFactoryBase : IEntityFactory<StoreOwnerEntity,
 
     public virtual StoreOwnerEntity CreateEntity(StoreOwnerCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(StoreOwnerEntity entity, StoreOwnerUpdateDto updateDto, Nox.Types.CultureCode cultureCode)
@@ -51,7 +58,7 @@ internal abstract class StoreOwnerFactoryBase : IEntityFactory<StoreOwnerEntity,
     private ClientApi.Domain.StoreOwner ToEntity(StoreOwnerCreateDto createDto)
     {
         var entity = new ClientApi.Domain.StoreOwner();
-        entity.Id = StoreOwnerMetadata.CreateId(createDto.Id!);
+        entity.Id = StoreOwnerMetadata.CreateId(createDto.Id);
         entity.Name = ClientApi.Domain.StoreOwnerMetadata.CreateName(createDto.Name);
         entity.TemporaryOwnerName = ClientApi.Domain.StoreOwnerMetadata.CreateTemporaryOwnerName(createDto.TemporaryOwnerName);
         entity.SetIfNotNull(createDto.VatNumber, (entity) => entity.VatNumber =ClientApi.Domain.StoreOwnerMetadata.CreateVatNumber(createDto.VatNumber.NonNullValue<VatNumberDto>()));

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TenantFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TenantFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class TenantFactoryBase : IEntityFactory<TenantEntity, TenantC
 
     public virtual TenantEntity CreateEntity(TenantCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(TenantEntity entity, TenantUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/WorkplaceFactory.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/WorkplaceFactory.g.cs
@@ -35,7 +35,14 @@ internal abstract class WorkplaceFactoryBase : IEntityFactory<WorkplaceEntity, W
 
     public virtual WorkplaceEntity CreateEntity(WorkplaceCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(WorkplaceEntity entity, WorkplaceUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountriesController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountriesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCountryCommand(country, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid || country is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountryQualityOfLifeIndicesController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CountryQualityOfLifeIndicesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CountryQualityOfLifeIndicesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCountryQualityOfLifeIndexCommand(countryQualityOfLifeIndex, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CountryQualityOfLifeIndicesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CountryQualityOfLifeIndicesControllerBase : ODataC
     {
         if (!ModelState.IsValid || countryQualityOfLifeIndex is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CurrenciesController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/CurrenciesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCurrencyCommand(currency, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CurrenciesControllerBase : ODataController
     {
         if (!ModelState.IsValid || currency is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/RatingProgramsController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/RatingProgramsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class RatingProgramsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateRatingProgramCommand(ratingProgram, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class RatingProgramsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class RatingProgramsControllerBase : ODataController
     {
         if (!ModelState.IsValid || ratingProgram is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoreLicensesController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoreLicensesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class StoreLicensesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateStoreLicenseCommand(storeLicense, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class StoreLicensesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class StoreLicensesControllerBase : ODataController
     {
         if (!ModelState.IsValid || storeLicense is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoreOwnersController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoreOwnersController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class StoreOwnersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateStoreOwnerCommand(storeOwner, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class StoreOwnersControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class StoreOwnersControllerBase : ODataController
     {
         if (!ModelState.IsValid || storeOwner is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoresController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/StoresController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class StoresControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateStoreCommand(store, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class StoresControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class StoresControllerBase : ODataController
     {
         if (!ModelState.IsValid || store is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TenantsController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TenantsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TenantsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTenantCommand(tenant, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TenantsControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TenantsControllerBase : ODataController
     {
         if (!ModelState.IsValid || tenant is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/WorkplacesController/Entity.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/WorkplacesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class WorkplacesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateWorkplaceCommand(workplace, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class WorkplacesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class WorkplacesControllerBase : ODataController
     {
         if (!ModelState.IsValid || workplace is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/WorkplacesController/Translations.g.cs
+++ b/src/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/WorkplacesController/Translations.g.cs
@@ -35,7 +35,7 @@ public abstract partial class WorkplacesControllerBase
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
         var etag = (await _mediator.Send(new GetWorkplaceByIdQuery(Nox.Types.CultureCode.From(cultureCode), key))).Select(e=>e.Etag).SingleOrDefault();
         

--- a/src/Nox.ClientApi.Tests/Nox.ClientApi.Tests.csproj
+++ b/src/Nox.ClientApi.Tests/Nox.ClientApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
 		<TargetFramework>net7.0</TargetFramework>

--- a/src/Nox.ClientApi.Tests/Tests/Application/Query/GetCountryByIdQueryValidatorTests.cs
+++ b/src/Nox.ClientApi.Tests/Tests/Application/Query/GetCountryByIdQueryValidatorTests.cs
@@ -26,10 +26,10 @@ namespace ClientApi.Tests.Tests.Controllers
         {
             // Act
             var result = await GetAsync($"{Endpoints.CountriesUrl}/301");
-            var response = await result.Content.ReadFromJsonAsync<SimpleResponse>();
+            var response = await result.Content.ReadFromJsonAsync<ApplicationErrorCodeResponse>();
             // Assert
-            response!.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-            response!.Message.Should().Contain("No permissions for keys greater than 300");
+            result!.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            response!.Error.Code.Should().Be("request_validation_exception");
         }
 
         /// <summary>

--- a/src/Nox.ClientApi.Tests/Tests/Controllers/TenantsControllerTests.cs
+++ b/src/Nox.ClientApi.Tests/Tests/Controllers/TenantsControllerTests.cs
@@ -57,10 +57,8 @@ namespace ClientApi.Tests.Controllers
             // Act
             var putResult = await PutAsync<TenantUpdateDto>($"{Endpoints.TenantsUrl}/{postResult!.Id}", updateDto, headers, false);
 
-            //Assert
-            var errorMessage = await putResult!.Content.ReadAsStringAsync();
-            errorMessage.Should().Contain("Immutable nuid property Id value is different since it has been initialized");
-            putResult.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            //Assert            
+            putResult!.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
 
         #region Many to Many Relations

--- a/src/Nox.ClientApi.Tests/Tests/Models/ApplicationErrorCodeResponse.cs
+++ b/src/Nox.ClientApi.Tests/Tests/Models/ApplicationErrorCodeResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace ClientApi.Tests.Tests.Models;
+
+public class ApplicationErrorCodeResponse
+{
+    public ApplicationError Error { get; set; } = null!;
+}
+public class ApplicationError
+{
+    public string Message { get; set; } = null!;
+    public uint Id { get; set; }
+    public string Code { get; set; } = null!;
+}

--- a/src/Nox.Generator/Application/Factories/EntityFactory.template.cs
+++ b/src/Nox.Generator/Application/Factories/EntityFactory.template.cs
@@ -51,7 +51,14 @@ internal abstract class {{className}}Base : IEntityFactory<{{entity.Name}}Entity
 
     public virtual {{entity.Name}}Entity CreateEntity({{entityCreateDto}} createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity({{entity.Name}}Entity entity, {{entityUpdateDto}} updateDto, Nox.Types.CultureCode cultureCode)

--- a/src/Nox.Generator/Presentation/Api/OData/EntityController.Entity.template.cs
+++ b/src/Nox.Generator/Presentation/Api/OData/EntityController.Entity.template.cs
@@ -79,7 +79,7 @@ public abstract partial class {{entity.PluralName}}ControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new Create{{entity.Name}}Command({{ToLowerFirstChar entity.Name}}, _cultureCode));
@@ -94,7 +94,7 @@ public abstract partial class {{entity.PluralName}}ControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
         {{~ if !entity.IsOwnedEntity }}
         var etag = Request.GetDecodedEtagHeader();
@@ -117,7 +117,7 @@ public abstract partial class {{entity.PluralName}}ControllerBase : ODataControl
     {
         if (!ModelState.IsValid || {{ToLowerFirstChar entity.Name}} is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/src/Nox.Generator/Presentation/Api/OData/EntityController.Translations.template.cs
+++ b/src/Nox.Generator/Presentation/Api/OData/EntityController.Translations.template.cs
@@ -39,7 +39,7 @@ public abstract partial class {{ className }}Base
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
         var etag = (await _mediator.Send(new Get{{entity.Name}}ByIdQuery(Nox.Types.CultureCode.From({{cultureCode}}), {{ primaryKeysQuery }}))).Select(e=>e.Etag).SingleOrDefault();
         

--- a/src/Nox.Lib/Application/Behaviors/ValidatorBehavior.cs
+++ b/src/Nox.Lib/Application/Behaviors/ValidatorBehavior.cs
@@ -39,7 +39,7 @@ namespace Nox.Application.Behaviors
 
             if (failures.Any())
             {
-                throw new TypeValidationException(failures);
+                throw new ValidationException(failures.ToList());
             }
 
             return await next();

--- a/src/Nox.Lib/Application/Dto/EntityDtoBase.cs
+++ b/src/Nox.Lib/Application/Dto/EntityDtoBase.cs
@@ -14,7 +14,7 @@ public abstract class EntityDtoBase
         {
             createAction();
         }
-        catch (TypeValidationException ex)
+        catch (NoxTypeValidationException ex)
         {
             validationResult.Add(propertyName, ex.Errors.Select(x => x.ErrorMessage));
         }

--- a/src/Nox.Lib/Application/Factories/CreateUpdateEntityInvalidDataException.cs
+++ b/src/Nox.Lib/Application/Factories/CreateUpdateEntityInvalidDataException.cs
@@ -1,0 +1,24 @@
+﻿using Nox.Exceptions;
+using Nox.Types;
+using System.Net;
+
+namespace Nox.Application.Factories
+{
+
+    /// <summary>
+    /// Innvalid data value provided to a nox type when creating or updating an Entity
+    /// </summary>
+    public sealed class CreateUpdateEntityInvalidDataException : Exception, IApplicationException
+    {
+        public CreateUpdateEntityInvalidDataException(NoxTypeValidationException innerException) : base(innerException.Message, innerException)
+        {
+            ErrorDetails = innerException.Errors;
+        }
+
+        public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+        public string ErrorCode => "create_update_invalid_data";
+
+        public object? ErrorDetails { get; }
+    }
+}

--- a/src/Nox.Lib/Application/ValidationException.cs
+++ b/src/Nox.Lib/Application/ValidationException.cs
@@ -1,0 +1,24 @@
+﻿using Nox.Exceptions;
+using Nox.Types;
+using System.Net;
+
+namespace Nox.Application
+{
+
+    /// <summary>
+    /// Commmand or Query Validation exception
+    /// </summary>
+    public sealed class ValidationException : Exception, IApplicationException
+    {
+        public ValidationException(object errorDetails) : base("Request validation exception")
+        {
+            ErrorDetails = errorDetails;
+        }
+
+        public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+        public string ErrorCode => "request_validation_exception";
+
+        public object? ErrorDetails { get; }
+    }
+}

--- a/src/Nox.Lib/Configuration/InvalidConfigurationException.cs
+++ b/src/Nox.Lib/Configuration/InvalidConfigurationException.cs
@@ -1,4 +1,6 @@
-﻿namespace Nox.Exceptions
+﻿using Nox.Presentation.Api;
+
+namespace Nox.Exceptions
 {
 
     /// <summary>

--- a/src/Nox.Lib/Domain/EntityAttributeIsNotNullableException.cs
+++ b/src/Nox.Lib/Domain/EntityAttributeIsNotNullableException.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Nox.Presentation.Api;
 
 namespace Nox.Exceptions
 {
-   /// <summary>
-   /// trying to set a null to a non nullable property
-   /// </summary>
+    /// <summary>
+    /// trying to set a null to a non nullable property
+    /// </summary>
     public class EntityAttributeIsNotNullableException : Exception
     {
         public EntityAttributeIsNotNullableException(string entityName, string attributeName): this($"{entityName} {attributeName} is not nullable")

--- a/src/Nox.Lib/Domain/RelatedEntityNotFoundException.cs
+++ b/src/Nox.Lib/Domain/RelatedEntityNotFoundException.cs
@@ -1,24 +1,34 @@
 ﻿using System.Net;
+using Elastic.Apm.Api;
+using Nox.Presentation.Api;
 using Nox.Types;
 
 namespace Nox.Exceptions;
 
-public class RelatedEntityNotFoundException : Exception, INoxHttpException
+public class RelatedEntityNotFoundException : Exception, IApplicationException
 {
     public RelatedEntityNotFoundException(string relatedEntityName, string relatedEntityId)
         : this($"{relatedEntityName} with Id {relatedEntityId} was not found")
     {
+        ErrorDetails = new { Entity = relatedEntityName , Key = relatedEntityId };
     }
 
     public RelatedEntityNotFoundException(string message)
         : base(message)
     {
+        ErrorDetails = message;
+
     }
 
     public RelatedEntityNotFoundException(string message, Exception inner)
         : base(message, inner)
     {
+        ErrorDetails = message;
     }
 
-    public HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+    public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+    public string ErrorCode => "related_entity_not_found";
+
+    public object? ErrorDetails { get; private set; }
 }

--- a/src/Nox.Lib/Domain/RelationshipDeletionException.cs
+++ b/src/Nox.Lib/Domain/RelationshipDeletionException.cs
@@ -1,9 +1,9 @@
 using System.Net;
-using Nox.Types;
+using Nox.Exceptions;
 
 namespace Nox.Domain;
 
-public class RelationshipDeletionException: Exception, INoxHttpException
+public class RelationshipDeletionException: Exception, IApplicationException
 {
     public RelationshipDeletionException(string message)
         : base(message)
@@ -15,5 +15,9 @@ public class RelationshipDeletionException: Exception, INoxHttpException
     {
     }
 
-    public HttpStatusCode StatusCode => HttpStatusCode.BadRequest;
+    public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+    public string ErrorCode => "can_not_delete_relationship";
+
+    public object? ErrorDetails => throw new NotImplementedException();
 }

--- a/src/Nox.Lib/Middlewares/NoxExceptionHanderMiddleware.cs
+++ b/src/Nox.Lib/Middlewares/NoxExceptionHanderMiddleware.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Nox.Exceptions;
 using Nox.Types;
 
 namespace Nox.Lib;
@@ -25,34 +26,61 @@ public class NoxExceptionHanderMiddleware
         {
             await _next(httpContext);
         }
-        catch (Exception ex) when (ex is INoxHttpException httpException)
+        catch (Exception ex) when (ex is IApplicationException exception)
         {
-            await CommonHandleExceptionAsync(httpContext, ex, httpException.StatusCode);
+            await CommonHandleExceptionAsync(
+                httpContext, 
+                ex, 
+                exception.ErrorCode,
+                exception.ErrorDetails, 
+                exception.StatusCode);
         }
         catch (Exception ex)
         {
-            await CommonHandleExceptionAsync(httpContext, ex, HttpStatusCode.InternalServerError);
+            await CommonHandleExceptionAsync(
+                httpContext, 
+                ex,
+                null,
+                null,
+                HttpStatusCode.InternalServerError);
         }
     }
-
-    private async Task CommonHandleExceptionAsync(HttpContext context,
+    /// <summary>
+    /// Setup the client response in case of unhandled exception
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="exception"></param>
+    /// <param name="errorCode">A short string with a brief explanation of the error to be returned to the client</param>
+    /// <param name="errorDetails">Optional: A complex object with more details about the error to be returned to the client</param>
+    /// <param name="statusCode">The Http Status Code</param>
+    /// <returns></returns>
+    private async Task CommonHandleExceptionAsync(
+        HttpContext context,
         Exception exception,
-        HttpStatusCode statusCode)
+        string? errorCode,
+        object? errorDetails,
+        HttpStatusCode? statusCode)
     {
-        var message = $"Error occurred during request: {context.Request?.Path}.Error: {exception.Message}";
+        var message = $"Error occurred during request: {context.Request?.Path}";
 
         _logger.LogError(exception, message);
 
         if (!context.Response.HasStarted)
         {
             context.Response.ContentType = "application/json";
-            context.Response.StatusCode = (int)statusCode;
+            context.Response.StatusCode = (int)(statusCode??HttpStatusCode.InternalServerError);
         }
 
         var error = JsonSerializer.Serialize(new
         {
-            statusCode,
-            message
+            error = new
+            {
+                message,
+                //Unique id for this error type, use error code if provided, otherwise use the exception type name
+                id = Nuid.From(errorCode ?? exception.GetType().FullName!).ToString(),
+                code = errorCode ?? "undefined",
+                details = errorDetails
+            }
         });
 
         await context.Response.WriteAsync(error);

--- a/src/Nox.Lib/Presentation/Api/BadRequestException.cs
+++ b/src/Nox.Lib/Presentation/Api/BadRequestException.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System.Net;
+
+namespace Nox.Exceptions;
+
+public sealed class BadRequestException : Exception, IApplicationException
+{
+    public BadRequestException(ModelStateDictionary modelState, string? errorCode = null) : base("bad request")
+    {
+        ErrorDetails = new SerializableError(modelState);
+
+        if (errorCode != null)
+        {
+            ErrorCode = errorCode;
+        }
+    }
+
+    public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
+
+    public string ErrorCode { get; private set; } = "bad_request";
+
+    public object? ErrorDetails { get; private set; }
+}

--- a/src/Nox.Lib/Presentation/Api/ConcurrencyException.cs
+++ b/src/Nox.Lib/Presentation/Api/ConcurrencyException.cs
@@ -1,9 +1,8 @@
 ﻿using System.Net;
-using Nox.Types;
 
 namespace Nox.Exceptions;
 
-public class ConcurrencyException : Exception, INoxHttpException
+public sealed class ConcurrencyException : System.Exception, IApplicationException
 {
     public ConcurrencyException(string message, HttpStatusCode statusCode)
         : base(message)
@@ -11,5 +10,9 @@ public class ConcurrencyException : Exception, INoxHttpException
         StatusCode = statusCode;
     }
 
-    public HttpStatusCode StatusCode { get; }
+    public HttpStatusCode? StatusCode { get; }
+
+    public string ErrorCode => "etag_invalid";
+
+    public object? ErrorDetails => Message;
 }

--- a/src/Nox.Types/Exceptions/INoxHttpException.cs
+++ b/src/Nox.Types/Exceptions/INoxHttpException.cs
@@ -1,8 +1,0 @@
-﻿using System.Net;
-
-namespace Nox.Types;
-
-public interface INoxHttpException
-{
-    HttpStatusCode StatusCode { get; }
-}

--- a/src/Nox.Types/Types/Area/Area.cs
+++ b/src/Nox.Types/Types/Area/Area.cs
@@ -28,7 +28,7 @@ public class Area : ValueObject<QuantityValue, Area>
     /// </summary>
     /// <param name="value">The value to create the <see cref="Area"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Area From(QuantityValue value)
         => From(value, new AreaTypeOptions());
 
@@ -38,7 +38,7 @@ public class Area : ValueObject<QuantityValue, Area>
     /// <param name="value">The value to create the <see cref="Area"/> with</param>
     /// <param name="unit">The unit to create the <see cref="Area"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Area From(QuantityValue value, AreaTypeUnit unit)
         => From(value, new AreaTypeOptions() { Units = unit });
 
@@ -48,7 +48,7 @@ public class Area : ValueObject<QuantityValue, Area>
     /// <param name="value">The value to create the <see cref="Area"/> with</param>
     /// <param name="options">The options to create the <see cref="Area"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Area From(QuantityValue value, AreaTypeOptions options)
     {
         var newObject = new Area
@@ -62,7 +62,7 @@ public class Area : ValueObject<QuantityValue, Area>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Color/Color.cs
+++ b/src/Nox.Types/Types/Color/Color.cs
@@ -34,7 +34,7 @@ public class Color : ValueObject<string, Color>
     /// <param name="red">The red color.</param>
     /// <param name="green">The green color.</param>
     /// <param name="blue">The blue color.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Color From(byte red, byte green, byte blue)
     {
         return From(255, red, green, blue);
@@ -47,7 +47,7 @@ public class Color : ValueObject<string, Color>
     /// <param name="red">The red color.</param>
     /// <param name="green">The green color.</param>
     /// <param name="blue">The blue color.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Color From(byte alpha, byte red, byte green, byte blue)
     {
         var color = System.Drawing.Color.FromArgb(alpha, red, green, blue);
@@ -59,7 +59,7 @@ public class Color : ValueObject<string, Color>
     /// </summary>
     /// <param name="name">The origin value to create the <see cref="Color"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Color FromName(string name)
     {
         var color = System.Drawing.Color.FromName(name);

--- a/src/Nox.Types/Types/CurrencyCode3/CurrencyCode3.cs
+++ b/src/Nox.Types/Types/CurrencyCode3/CurrencyCode3.cs
@@ -31,7 +31,7 @@ public sealed class CurrencyCode3 : ValueObject<string, CurrencyCode3>
     /// </summary>
     /// <param name="value">The string to create the <see cref="CurrencyCode3"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException">If the currencyCode3 is invalid.</exception>
+    /// <exception cref="NoxTypeValidationException">If the currencyCode3 is invalid.</exception>
     public new static CurrencyCode3 From(string value)
     {
         var newObject = new CurrencyCode3
@@ -43,7 +43,7 @@ public sealed class CurrencyCode3 : ValueObject<string, CurrencyCode3>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Date/Date.cs
+++ b/src/Nox.Types/Types/Date/Date.cs
@@ -18,7 +18,7 @@ public sealed class Date : ValueObject<DateOnly, Date>
     /// </summary>
     /// <param name="date">The date time to create date from.</param>
     /// <param name="dateTypeOptions">The date type options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Date From(DateOnly date, DateTypeOptions dateTypeOptions)
     {
         var newObject = new Date
@@ -31,7 +31,7 @@ public sealed class Date : ValueObject<DateOnly, Date>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;
@@ -44,7 +44,7 @@ public sealed class Date : ValueObject<DateOnly, Date>
     /// <param name="month">The month.</param>
     /// <param name="day">The day.</param>
     /// <param name="dateTypeOptions">The date type options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Date From(int year, int month, int day, DateTypeOptions? dateTypeOptions = null)
     {
         var date = new DateOnly(year, month, day);
@@ -56,7 +56,7 @@ public sealed class Date : ValueObject<DateOnly, Date>
     /// </summary>
     /// <param name="dateTime">The date time.</param>
     /// <param name="dateTypeOptions">The date type options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Date From(System.DateTime dateTime, DateTypeOptions? dateTypeOptions = null)
     {
         var date = DateOnly.FromDateTime(dateTime);

--- a/src/Nox.Types/Types/DateTime/DateTime.cs
+++ b/src/Nox.Types/Types/DateTime/DateTime.cs
@@ -28,7 +28,7 @@ public sealed class DateTime : ValueObject<DateTimeOffset, DateTime>
     /// <param name="timespan"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTime From(System.DateTime dateTime, TimeSpan timespan, DateTimeTypeOptions? options = null)
     {
         options ??= new DateTimeTypeOptions();
@@ -55,7 +55,7 @@ public sealed class DateTime : ValueObject<DateTimeOffset, DateTime>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/DateTimeDuration/DateTimeDuration.cs
+++ b/src/Nox.Types/Types/DateTimeDuration/DateTimeDuration.cs
@@ -26,7 +26,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <remarks>
     /// There are 10 000 ticks in a millisecond
     /// </remarks>
-    /// <exception cref="Nox.Types.TypeValidationException"></exception>
+    /// <exception cref="Nox.Types.NoxTypeValidationException"></exception>
     public static DateTimeDuration From(long ticks, DateTimeDurationTypeOptions options)
     {
         var newObject = new DateTimeDuration
@@ -40,7 +40,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;
@@ -53,7 +53,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <remarks>
     /// There are 10 000 ticks in a millisecond
     /// </remarks>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static DateTimeDuration From(long ticks)
         => From(ticks, new());
 
@@ -63,7 +63,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <param name="timeSpan">The time span to create date time duration from.</param>
     /// <param name="options">The options.</param>
     /// <returns></returns>
-    /// <exception cref="Nox.Types.TypeValidationException"></exception>
+    /// <exception cref="Nox.Types.NoxTypeValidationException"></exception>
     public static DateTimeDuration From(TimeSpan timeSpan, DateTimeDurationTypeOptions options)
         => From(timeSpan.Duration().Ticks, options);
 
@@ -71,7 +71,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// Creates a new instance of <see cref="DateTimeDuration"/> object.
     /// </summary>
     /// <param name="timeSpan">The time span to create date time duration from.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration From(TimeSpan timeSpan)
         => From(timeSpan, new());
 
@@ -84,7 +84,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <param name="seconds">The seconds.</param>
     /// <param name="milliseconds">The milliseconds.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration From(int days, int hours, int minutes, int seconds, int milliseconds, DateTimeDurationTypeOptions? options = null)
         => From(new TimeSpan(days, hours, minutes, seconds, milliseconds), options ?? new());
 
@@ -96,7 +96,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <param name="minutes">The minutes.</param>
     /// <param name="seconds">The seconds.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration From(int days, int hours, int minutes, int seconds, DateTimeDurationTypeOptions? options = null)
         => From(new TimeSpan(days, hours, minutes, seconds), options ?? new());
 
@@ -107,7 +107,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// <param name="minutes">The minutes.</param>
     /// <param name="seconds">The seconds.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration From(int hours, int minutes, int seconds, DateTimeDurationTypeOptions? options = null)
         => From(new TimeSpan(hours, minutes, seconds), options ?? new());
 
@@ -116,7 +116,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// </summary>
     /// <param name="days">The days.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration FromDays(double days, DateTimeDurationTypeOptions? options = null)
         => From(TimeSpan.FromDays(days), options ?? new());
 
@@ -125,7 +125,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// </summary>
     /// <param name="hours">The hours.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration FromHours(double hours, DateTimeDurationTypeOptions? options = null)
         => From(TimeSpan.FromHours(hours), options ?? new());
 
@@ -134,7 +134,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// </summary>
     /// <param name="minutes">The minutes.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration FromMinutes(double minutes, DateTimeDurationTypeOptions? options = null)
         => From(TimeSpan.FromMinutes(minutes), options ?? new());
 
@@ -143,7 +143,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// </summary>
     /// <param name="seconds">The seconds.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration FromSeconds(double seconds, DateTimeDurationTypeOptions? options = null)
         => From(TimeSpan.FromSeconds(seconds), options ?? new());
 
@@ -152,7 +152,7 @@ public sealed class DateTimeDuration : ValueObject<long, DateTimeDuration>
     /// </summary>
     /// <param name="milliseconds">The milliseconds.</param>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeDuration FromMilliseconds(double milliseconds, DateTimeDurationTypeOptions? options = null)
         => From(TimeSpan.FromMilliseconds(milliseconds), options ?? new());
 

--- a/src/Nox.Types/Types/DateTimeRange/DateTimeRange.cs
+++ b/src/Nox.Types/Types/DateTimeRange/DateTimeRange.cs
@@ -43,7 +43,7 @@ public class DateTimeRange : ValueObject<(DateTimeOffset Start, DateTimeOffset E
     /// </summary>
     /// <param name="value">The value.</param>
     /// <param name="dateTimeRangeTypeOptions">The date time range type options.</param>
-    /// <exception cref="Nox.Types.TypeValidationException"></exception>
+    /// <exception cref="Nox.Types.NoxTypeValidationException"></exception>
     public static DateTimeRange From((DateTimeOffset Start, DateTimeOffset End) value, DateTimeRangeTypeOptions dateTimeRangeTypeOptions)
     {
         var newObject = new DateTimeRange
@@ -56,7 +56,7 @@ public class DateTimeRange : ValueObject<(DateTimeOffset Start, DateTimeOffset E
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;
@@ -66,7 +66,7 @@ public class DateTimeRange : ValueObject<(DateTimeOffset Start, DateTimeOffset E
     /// Creates a new instance of <see cref="DateTimeRange"/> with specified start and end date and time and with default type options.
     /// </summary>
     /// <param name="value">The value.</param>
-    /// <exception cref="Nox.Types.TypeValidationException"></exception>
+    /// <exception cref="Nox.Types.NoxTypeValidationException"></exception>
     public new static DateTimeRange From((DateTimeOffset Start, DateTimeOffset End) value)
         => From(value, new DateTimeRangeTypeOptions());
 
@@ -76,7 +76,7 @@ public class DateTimeRange : ValueObject<(DateTimeOffset Start, DateTimeOffset E
     /// <param name="start">The start.</param>
     /// <param name="end">The end.</param>
     /// <param name="dateTimeRangeTypeOptions">The date time range type options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeRange From(DateTimeOffset start, DateTimeOffset end, DateTimeRangeTypeOptions? dateTimeRangeTypeOptions = null)
         => From((start, end), dateTimeRangeTypeOptions ?? new DateTimeRangeTypeOptions());
 
@@ -86,7 +86,7 @@ public class DateTimeRange : ValueObject<(DateTimeOffset Start, DateTimeOffset E
     /// <param name="start">The start.</param>
     /// <param name="duration">The duration of the range.</param>
     /// <param name="dateTimeRangeTypeOptions">The date time range type options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static DateTimeRange From(DateTimeOffset start, TimeSpan duration, DateTimeRangeTypeOptions? dateTimeRangeTypeOptions = null)
             => From((start, start.Add(duration)), dateTimeRangeTypeOptions ?? new DateTimeRangeTypeOptions());
 

--- a/src/Nox.Types/Types/DateTimeSchedule/DateTimeSchedule.cs
+++ b/src/Nox.Types/Types/DateTimeSchedule/DateTimeSchedule.cs
@@ -37,7 +37,7 @@ public class DateTimeSchedule : ValueObject<string, DateTimeSchedule>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Distance/Distance.cs
+++ b/src/Nox.Types/Types/Distance/Distance.cs
@@ -26,7 +26,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// </summary>
     /// <param name="value">The value to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Distance From(QuantityValue value)
         => From(value, new DistanceTypeOptions());
 
@@ -36,7 +36,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// <param name="value">The value to create the <see cref="Distance"/> with</param>
     /// <param name="unit">The unit to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Distance From(QuantityValue value, DistanceTypeUnit unit)
         => From(value, new DistanceTypeOptions() { Units = unit });
 
@@ -46,7 +46,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// <param name="origin">The origin <see cref="LatLong"/> to create the <see cref="Distance"/> with</param>
     /// <param name="destination">The destination <see cref="LatLong"/> to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Distance From(LatLong origin, LatLong destination)
         => From(origin, destination, new DistanceTypeOptions());
 
@@ -57,7 +57,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// <param name="destination">The destination <see cref="LatLong"/> to create the <see cref="Distance"/> with</param>
     /// <param name="unit">The <see cref="DistanceTypeUnit"/> to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Distance From(LatLong origin, LatLong destination, DistanceTypeUnit unit) 
         => From(origin, destination, new DistanceTypeOptions { Units = unit });
 
@@ -68,7 +68,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// <param name="destination">The destination <see cref="LatLong"/> to create the <see cref="Distance"/> with</param>
     /// <param name="options">The <see cref="DistanceTypeOptions"/> to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Distance From(LatLong origin, LatLong destination, DistanceTypeOptions options)
     {
         var distanceValue = new HaversineDistanceCalculator().Calculate(origin, destination, options.Units);
@@ -81,7 +81,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
     /// <param name="value">The value to create the <see cref="Distance"/> with</param>
     /// <param name="options">The options to create the <see cref="Distance"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Distance From(QuantityValue value, DistanceTypeOptions options)
     {
         var newObject = new Distance
@@ -95,7 +95,7 @@ public class Distance : ValueObject<QuantityValue, Distance>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Email/Email.cs
+++ b/src/Nox.Types/Types/Email/Email.cs
@@ -44,7 +44,7 @@ public sealed class Email : ValueObject<string, Email>
 
         if (!validationResult.IsValid)
         {
-            throw new  TypeValidationException(validationResult.Errors);
+            throw new  NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/EncryptedText/EncryptedText.cs
+++ b/src/Nox.Types/Types/EncryptedText/EncryptedText.cs
@@ -26,7 +26,7 @@ public sealed class EncryptedText : ValueObject<byte[], EncryptedText>
     /// <param name="value">Plain text to be encrypted.</param>
     /// <param name="typeOptions">Options used for encryption.</param>
     /// <returns>Encrypted text.</returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static EncryptedText FromPlainText(string value, EncryptedTextTypeOptions typeOptions)
     {
         var newObject = new EncryptedText
@@ -38,7 +38,7 @@ public sealed class EncryptedText : ValueObject<byte[], EncryptedText>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Enumeration/Enumeration.cs
+++ b/src/Nox.Types/Types/Enumeration/Enumeration.cs
@@ -40,7 +40,7 @@ public sealed class Enumeration : ValueObject<int, Enumeration>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;
@@ -66,7 +66,7 @@ public sealed class Enumeration : ValueObject<int, Enumeration>
             var result = new ValidationResult();
             result.Errors.Add(new ValidationFailure(nameof(Value), $"No enumerator exists with an Description of '{stringValue}'."));
 
-            throw new TypeValidationException(result.Errors);
+            throw new NoxTypeValidationException(result.Errors);
         }
 
         return From((int)value, options);

--- a/src/Nox.Types/Types/File/File.cs
+++ b/src/Nox.Types/Types/File/File.cs
@@ -47,7 +47,7 @@ public sealed class File : ValueObject<(string Url, string PrettyName, ulong Siz
     /// <param name="value">The value.</param>
     /// <param name="options">The options.</param>
     /// <returns></returns>
-    /// <exception cref="Nox.Types.TypeValidationException"></exception>
+    /// <exception cref="Nox.Types.NoxTypeValidationException"></exception>
     public static File From((string Url, string PrettyName, ulong SizeInBytes) value, FileTypeOptions options)
     {
         var newObject = new File
@@ -60,7 +60,7 @@ public sealed class File : ValueObject<(string Url, string PrettyName, ulong Siz
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Formula/Formula.cs
+++ b/src/Nox.Types/Types/Formula/Formula.cs
@@ -17,7 +17,7 @@ public class Formula : ValueObject<string, Formula>
     /// Creates a new instance of <see cref="Formula"/> object.
     /// </summary>
     /// <param name="options">The options.</param>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Formula From(FormulaTypeOptions options)
     {
         var newObject = new Formula
@@ -30,7 +30,7 @@ public class Formula : ValueObject<string, Formula>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Guid/Guid.cs
+++ b/src/Nox.Types/Types/Guid/Guid.cs
@@ -17,12 +17,12 @@ public sealed class Guid : ValueObject<System.Guid, Guid>
     /// </summary>
     /// <param name="value">String to be parsed to <see cref="Guid"/>.</param>
     /// <returns>New instance of <see cref="Guid"/>.</returns>
-    /// <exception cref="TypeValidationException">In case the <paramref name="value"/> contains an invalid Guid.</exception>
+    /// <exception cref="NoxTypeValidationException">In case the <paramref name="value"/> contains an invalid Guid.</exception>
     public static Guid From(string value)
     {
         if (!System.Guid.TryParse(value, out var parsedGuid))
         {
-            throw new TypeValidationException(
+            throw new NoxTypeValidationException(
                 new List<ValidationFailure>
                 {
                     new(nameof(value),
@@ -39,7 +39,7 @@ public sealed class Guid : ValueObject<System.Guid, Guid>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/HashedText/HashedText.cs
+++ b/src/Nox.Types/Types/HashedText/HashedText.cs
@@ -39,7 +39,7 @@ public sealed class HashedText : ValueObject<(string HashText, string Salt), Has
     /// <param name="plainText">Plain text that will be hashed</param>
     /// <param name="options"><see cref="HashedTextTypeOptions"/></param>
     /// <returns>New instance of <see cref="HashedText"/></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static HashedText From(string plainText, HashedTextTypeOptions options)
     {
         options ??= new HashedTextTypeOptions();
@@ -50,7 +50,7 @@ public sealed class HashedText : ValueObject<(string HashText, string Salt), Has
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Html/Html.cs
+++ b/src/Nox.Types/Types/Html/Html.cs
@@ -12,7 +12,7 @@ public sealed class Html : ValueObject<string, Html>
     /// </summary>
     /// <param name="value">String to be parsed to <see cref="Html"/>.</param>
     /// <returns>New instance of <see cref="Html"/>.</returns>
-    /// <exception cref="TypeValidationException">In case the <paramref name="value"/> contains an invalid html.</exception>
+    /// <exception cref="NoxTypeValidationException">In case the <paramref name="value"/> contains an invalid html.</exception>
     public new static Html From(string value)
     {
         var newObject = new Html
@@ -24,7 +24,7 @@ public sealed class Html : ValueObject<string, Html>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Image/Image.cs
+++ b/src/Nox.Types/Types/Image/Image.cs
@@ -81,7 +81,7 @@ public sealed class Image : ValueObject<(string Url, string PrettyName, int Size
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/IpAddress/IpAddress.cs
+++ b/src/Nox.Types/Types/IpAddress/IpAddress.cs
@@ -11,7 +11,7 @@ public sealed class IpAddress : ValueObject<string, IpAddress>
     /// </summary>
     /// <param name="value">The value to create the <see cref="IpAddress"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static IpAddress From(string value)
     {
         TryParse(value, out var ipAddressValue);
@@ -25,7 +25,7 @@ public sealed class IpAddress : ValueObject<string, IpAddress>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Json/Json.cs
+++ b/src/Nox.Types/Types/Json/Json.cs
@@ -40,7 +40,7 @@ public sealed class Json : ValueObject<string, Json>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         newObject.ApplyOptions();

--- a/src/Nox.Types/Types/Length/Length.cs
+++ b/src/Nox.Types/Types/Length/Length.cs
@@ -28,7 +28,7 @@ public class Length : ValueObject<QuantityValue, Length>
     /// </summary>
     /// <param name="value">The value to create the <see cref="Length"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Length From(QuantityValue value)
         => From(value, new LengthTypeOptions());
 
@@ -38,7 +38,7 @@ public class Length : ValueObject<QuantityValue, Length>
     /// <param name="value">The value to create the <see cref="Length"/> with</param>
     /// <param name="unit">The unit to create the <see cref="Length"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Length From(QuantityValue value, LengthTypeUnit unit)
         => From(value, new LengthTypeOptions() { Units = unit });
 
@@ -48,7 +48,7 @@ public class Length : ValueObject<QuantityValue, Length>
     /// <param name="value">The value to create the <see cref="Length"/> with</param>
     /// <param name="options">The options to create the <see cref="Length"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Length From(QuantityValue value, LengthTypeOptions options)
     {
         var newObject = new Length
@@ -62,7 +62,7 @@ public class Length : ValueObject<QuantityValue, Length>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/MacAddress/MacAddress.cs
+++ b/src/Nox.Types/Types/MacAddress/MacAddress.cs
@@ -18,7 +18,7 @@ public sealed class MacAddress : ValueObject<string, MacAddress>
     /// </summary>
     /// <param name="macAddressText">The string value to create the <see cref="MacAddress"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static MacAddress From(string macAddressText)
     {
         TryParse(macAddressText, out string macAddressValue);
@@ -32,7 +32,7 @@ public sealed class MacAddress : ValueObject<string, MacAddress>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;
@@ -43,7 +43,7 @@ public sealed class MacAddress : ValueObject<string, MacAddress>
     /// </summary>
     /// <param name="macAddressHexNumber">The ulong value to create the <see cref="MacAddress"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static MacAddress From(ulong macAddressHexNumber)
     {
         var macAddressValue = PadToMacAddressLength(macAddressHexNumber.ToString("X2", CultureInfo.InvariantCulture));
@@ -55,7 +55,7 @@ public sealed class MacAddress : ValueObject<string, MacAddress>
     /// </summary>
     /// <param name="macAddressBytes">The byte array value to create the <see cref="MacAddress"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static MacAddress From(byte[] macAddressBytes)
     {
         var macAddressValue = ConvertToHexString(macAddressBytes);

--- a/src/Nox.Types/Types/Markdown/Markdown.cs
+++ b/src/Nox.Types/Types/Markdown/Markdown.cs
@@ -16,7 +16,7 @@ public sealed class Markdown : ValueObject<string, Markdown>
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Markdown From(string value) => From(value, new MarkdownTypeOptions());
 
     /// <summary>
@@ -25,7 +25,7 @@ public sealed class Markdown : ValueObject<string, Markdown>
     /// <param name="value"></param>
     /// <param name="typeOptions"></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Markdown From(string value, MarkdownTypeOptions typeOptions)
     {
         var newObject = new Markdown
@@ -38,7 +38,7 @@ public sealed class Markdown : ValueObject<string, Markdown>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Money/Money.cs
+++ b/src/Nox.Types/Types/Money/Money.cs
@@ -57,7 +57,7 @@ public class Money : ValueObject<(decimal Amount, CurrencyCode CurrencyCode), Mo
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Month/Month.cs
+++ b/src/Nox.Types/Types/Month/Month.cs
@@ -28,7 +28,7 @@ public class Month : ValueObject<byte, Month>
     /// </summary>
     /// <param name="value">The value to be used for the value object.</param>
     /// <returns>The newly created value object instance.</returns>
-    /// <exception cref="TypeValidationException">Thrown when the validation of the value object fails.</exception>
+    /// <exception cref="NoxTypeValidationException">Thrown when the validation of the value object fails.</exception>
     public static Month From(int value)
     {
         var month = new Month() { Value = (byte)value, _value = value};
@@ -36,7 +36,7 @@ public class Month : ValueObject<byte, Month>
         var validationResult = month.Validate();
         if(!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return month;

--- a/src/Nox.Types/Types/Number/Number.cs
+++ b/src/Nox.Types/Types/Number/Number.cs
@@ -34,7 +34,7 @@ public class Number : ValueObject<QuantityValue, Number>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Password/Password.cs
+++ b/src/Nox.Types/Types/Password/Password.cs
@@ -37,14 +37,14 @@ public sealed class Password : ValueObject<(string HashedPassword, string Salt),
     /// <param name="value">Plain text that will be hashed</param>
     /// <param name="options"><see cref="PasswordTypeOptions"/></param>
     /// <returns>New instance of <see cref="Password"/></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Password From(string value, PasswordTypeOptions options)
     {
         var validationResult = Validate(value, options);
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         var newObject = new Password
@@ -60,7 +60,7 @@ public sealed class Password : ValueObject<(string HashedPassword, string Salt),
     /// </summary>
     /// <param name="value">Plain text that will be hashed</param>
     /// <returns>New instance of <see cref="Password"/></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Password From(string value)
         => From(value, new PasswordTypeOptions());
 

--- a/src/Nox.Types/Types/Percentage/Percentage.cs
+++ b/src/Nox.Types/Types/Percentage/Percentage.cs
@@ -15,7 +15,7 @@ public sealed class Percentage : ValueObject<float, Percentage>
     /// </summary>
     /// <param name="value">The value to create the <see cref="Percentage"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Percentage From(float value, PercentageTypeOptions options)
     {
         var newObject = new Percentage
@@ -28,7 +28,7 @@ public sealed class Percentage : ValueObject<float, Percentage>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Temperature/Temperature.cs
+++ b/src/Nox.Types/Types/Temperature/Temperature.cs
@@ -20,7 +20,7 @@ public class Temperature : ValueObject<QuantityValue, Temperature>
     /// </summary>
     /// <param name="value">The value of <see cref="Temperature"/></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Temperature From(QuantityValue value)
     {
         return From(value, new TemperatureTypeOptions());
@@ -32,7 +32,7 @@ public class Temperature : ValueObject<QuantityValue, Temperature>
     /// <param name="value">The value of <see cref="Temperature"/></param>
     /// <param name="temperatureUnit">The unit of <see cref="Temperature"/></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Temperature From(QuantityValue value, TemperatureTypeUnit temperatureUnit)
     {
         return From(value, new TemperatureTypeOptions() { Units = temperatureUnit });
@@ -44,7 +44,7 @@ public class Temperature : ValueObject<QuantityValue, Temperature>
     /// <param name="value">The value of <see cref="Temperature"/></param>
     /// <param name="options">The options of type <see cref="TemperatureTypeOptions"/></param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Temperature From(QuantityValue value, TemperatureTypeOptions options)
     {
         var newObject = new Temperature
@@ -58,7 +58,7 @@ public class Temperature : ValueObject<QuantityValue, Temperature>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Text/Text.cs
+++ b/src/Nox.Types/Types/Text/Text.cs
@@ -31,7 +31,7 @@ public sealed class Text : ValueObject<string, Text>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Time/Time.cs
+++ b/src/Nox.Types/Types/Time/Time.cs
@@ -71,7 +71,7 @@ public sealed class Time : ValueObject<TimeOnly, Time>
 
         if (!result.IsValid)
         {
-            throw new TypeValidationException(result.Errors);
+            throw new NoxTypeValidationException(result.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/TranslatedText/TranslatedText.cs
+++ b/src/Nox.Types/Types/TranslatedText/TranslatedText.cs
@@ -59,7 +59,7 @@ public sealed class TranslatedText : ValueObject<(CultureCode CultureCode, strin
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Uri/Uri.cs
+++ b/src/Nox.Types/Types/Uri/Uri.cs
@@ -13,7 +13,7 @@ public sealed class Uri : ValueObject<System.Uri, Uri>
     {
         if (value.Length > MaxLength)
         {
-            throw new TypeValidationException(
+            throw new NoxTypeValidationException(
                 new List<ValidationFailure>
                 {
                     new ValidationFailure("Uri",
@@ -23,7 +23,7 @@ public sealed class Uri : ValueObject<System.Uri, Uri>
         
         if (!System.Uri.TryCreate(value, uriKind, out var uriValue))
         {
-            throw new TypeValidationException(
+            throw new NoxTypeValidationException(
                 new List<ValidationFailure> {
                     new ValidationFailure("Uri", $"The string '{value}' you provided, is not a valid Uri.") });
         }

--- a/src/Nox.Types/Types/Url/Url.cs
+++ b/src/Nox.Types/Types/Url/Url.cs
@@ -20,14 +20,14 @@ public sealed class Url : ValueObject<System.Uri, Url>
     {
         if (value.Length > MaxLength)
         {
-            throw new TypeValidationException(
+            throw new NoxTypeValidationException(
                 new List<ValidationFailure> { new("Value", $"Could not create a Nox Url type as value {value} is greater than the specified maximum of {MaxLength}") }
             );
         }
 
         if (!System.Uri.TryCreate(value, UriKind.Absolute, out var uriValue))
         {
-            throw new TypeValidationException(
+            throw new NoxTypeValidationException(
                 new List<ValidationFailure> { new("Value", $"Could not create a Nox Url type as value {value} is not a valid Url.") }
             );
         }
@@ -38,7 +38,7 @@ public sealed class Url : ValueObject<System.Uri, Url>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/User/User.cs
+++ b/src/Nox.Types/Types/User/User.cs
@@ -34,7 +34,7 @@ public sealed class User : ValueObject<string, User>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/VatNumber/VatNumber.cs
+++ b/src/Nox.Types/Types/VatNumber/VatNumber.cs
@@ -89,7 +89,7 @@ public sealed class VatNumber : ValueObject<(string Number, CountryCode CountryC
 
             result.Errors.Add(new ValidationFailure(nameof(countryCode), $"Invalid alpha-2 country code specified ('{countryCode}')."));
 
-            throw new TypeValidationException(result.Errors);
+            throw new NoxTypeValidationException(result.Errors);
         }
         return From(value, code);
     }

--- a/src/Nox.Types/Types/Volume/Volume.cs
+++ b/src/Nox.Types/Types/Volume/Volume.cs
@@ -41,7 +41,7 @@ public class Volume : ValueObject<QuantityValue, Volume>
     /// </summary>
     /// <param name="value">The origin value to create the <see cref="Volume"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Volume From(QuantityValue value)
         => From(value, new VolumeTypeOptions());
 
@@ -51,7 +51,7 @@ public class Volume : ValueObject<QuantityValue, Volume>
     /// <param name="value">Value to create a <see cref="Volume"/>.</param>
     /// <param name="unit">Unit to create a <see cref="Volume"/>.</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Volume From(QuantityValue value, VolumeTypeUnit unit)
         => From(value, new VolumeTypeOptions { Unit = unit });
 
@@ -61,7 +61,7 @@ public class Volume : ValueObject<QuantityValue, Volume>
     /// <param name="value">Value to create a <see cref="Volume"/>.</param>
     /// <param name="options">Options to create a <see cref="Volume"/>.</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Volume From(QuantityValue value, VolumeTypeOptions options)
     {
         var newObject = new Volume
@@ -75,7 +75,7 @@ public class Volume : ValueObject<QuantityValue, Volume>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Weight/Weight.cs
+++ b/src/Nox.Types/Types/Weight/Weight.cs
@@ -28,7 +28,7 @@ public class Weight : ValueObject<QuantityValue, Weight>
     /// </summary>
     /// <param name="value">The value to create the <see cref="Weight"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public new static Weight From(QuantityValue value)
         => From(value, new WeightTypeOptions());
 
@@ -38,7 +38,7 @@ public class Weight : ValueObject<QuantityValue, Weight>
     /// <param name="value">The value to create the <see cref="Weight"/> with</param>
     /// <param name="unit">The unit to create the <see cref="Weight"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Weight From(QuantityValue value, WeightTypeUnit unit)
         => From(value, new WeightTypeOptions() { Units = unit });
 
@@ -48,7 +48,7 @@ public class Weight : ValueObject<QuantityValue, Weight>
     /// <param name="value">The value to create the <see cref="Weight"/> with</param>
     /// <param name="options">The options to create the <see cref="Weight"/> with</param>
     /// <returns></returns>
-    /// <exception cref="TypeValidationException"></exception>
+    /// <exception cref="NoxTypeValidationException"></exception>
     public static Weight From(QuantityValue value, WeightTypeOptions options)
     {
         var newObject = new Weight
@@ -62,7 +62,7 @@ public class Weight : ValueObject<QuantityValue, Weight>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Types/Year/Year.cs
+++ b/src/Nox.Types/Types/Year/Year.cs
@@ -28,7 +28,7 @@ public sealed class Year : ValueObject<ushort, Year>
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/src/Nox.Types/Validation/NoxTypeValidationException.cs
+++ b/src/Nox.Types/Validation/NoxTypeValidationException.cs
@@ -1,29 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Runtime.Serialization;
 
 namespace Nox.Types;
 
 [Serializable]
-public class TypeValidationException : Exception, INoxHttpException
+public class NoxTypeValidationException : Exception
 {
     private readonly List<ValidationFailure> _errors = new();
     public IReadOnlyList<ValidationFailure> Errors => _errors;
 
-    public TypeValidationException(IEnumerable<ValidationFailure> errors)
+    public NoxTypeValidationException(IEnumerable<ValidationFailure> errors)
     : base($"The Nox type validation failed with {errors.Count()} error(s).")
     {
         _errors.AddRange(errors);
     }
 
-    protected TypeValidationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
+    protected NoxTypeValidationException(SerializationInfo serializationInfo, StreamingContext streamingContext)
         : base(serializationInfo, streamingContext)
     {
     }
-
     public override string Message => $"{base.Message} {string.Join("\n", Errors.Select(x => $"PropertyName: {x.Variable}. Error: {x.ErrorMessage}"))}";
-
-    public HttpStatusCode StatusCode { get; } = HttpStatusCode.BadRequest;
 }

--- a/src/Nox.Types/Validation/ValidationFailure.cs
+++ b/src/Nox.Types/Validation/ValidationFailure.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nox.Types;
 
-public class ValidationFailure
+public sealed class ValidationFailure
 {
     public string Variable { get; private set; }
     public string ErrorMessage { get; private set; }

--- a/src/Nox.Types/ValueObjectBase/ValueObject.cs
+++ b/src/Nox.Types/ValueObjectBase/ValueObject.cs
@@ -38,7 +38,7 @@ public abstract class ValueObject<T, TValueObject> : INoxType
     /// </summary>
     /// <param name="value">The value to be used for the value object.</param>
     /// <returns>The newly created value object instance.</returns>
-    /// <exception cref="TypeValidationException">Thrown when the validation of the value object fails.</exception>
+    /// <exception cref="NoxTypeValidationException">Thrown when the validation of the value object fails.</exception>
     public static TValueObject From(T value)
     {
         var newObject = new TValueObject
@@ -50,7 +50,7 @@ public abstract class ValueObject<T, TValueObject> : INoxType
 
         if (!validationResult.IsValid)
         {
-            throw new TypeValidationException(validationResult.Errors);
+            throw new NoxTypeValidationException(validationResult.Errors);
         }
 
         return newObject;

--- a/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Application.Factories.CountryFactory.expected.g.cs
+++ b/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Application.Factories.CountryFactory.expected.g.cs
@@ -35,7 +35,14 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 
     public virtual CountryEntity CreateEntity(CountryCreateDto createDto)
     {
-        return ToEntity(createDto);
+        try
+        {
+            return ToEntity(createDto);
+        }
+        catch (NoxTypeValidationException ex)
+        {
+            throw new Nox.Application.Factories.CreateUpdateEntityInvalidDataException(ex);
+        }        
     }
 
     public virtual void UpdateEntity(CountryEntity entity, CountryUpdateDto updateDto, Nox.Types.CultureCode cultureCode)

--- a/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CitiesController.Entity.g.cs
+++ b/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CitiesController.Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CitiesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCityCommand(city, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CitiesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CitiesControllerBase : ODataController
     {
         if (!ModelState.IsValid || city is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CitiesController.Translations.g.cs
+++ b/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CitiesController.Translations.g.cs
@@ -35,7 +35,7 @@ public abstract partial class CitiesControllerBase
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
         var etag = (await _mediator.Send(new GetCityByIdQuery(Nox.Types.CultureCode.From(cultureCode), key))).Select(e=>e.Etag).SingleOrDefault();
         

--- a/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CompoundKeysEntitiesController.Entity.g.cs
+++ b/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CompoundKeysEntitiesController.Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class CompoundKeysEntitiesControllerBase : ODataControll
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCompoundKeysEntityCommand(compoundKeysEntity, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class CompoundKeysEntitiesControllerBase : ODataControll
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class CompoundKeysEntitiesControllerBase : ODataControll
     {
         if (!ModelState.IsValid || compoundKeysEntity is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CountriesController.Entity.g.cs
+++ b/tests/Nox.Generator.Tests/ExpectedGeneratedFiles/Presentation.Api.OData.CountriesController.Entity.g.cs
@@ -73,7 +73,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateCountryCommand(country, _cultureCode));
@@ -87,7 +87,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -107,7 +107,7 @@ public abstract partial class CountriesControllerBase : ODataController
     {
         if (!ModelState.IsValid || country is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EntityUniqueConstraintsRelatedForeignKeyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EntityUniqueConstraintsRelatedForeignKeyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class EntityUniqueConstraintsRelatedForeignKeyFactoryBase : IE
     private TestWebApp.Domain.EntityUniqueConstraintsRelatedForeignKey ToEntity(EntityUniqueConstraintsRelatedForeignKeyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.EntityUniqueConstraintsRelatedForeignKey();
-        entity.Id = EntityUniqueConstraintsRelatedForeignKeyMetadata.CreateId(createDto.Id!);
+        entity.Id = EntityUniqueConstraintsRelatedForeignKeyMetadata.CreateId(createDto.Id);
         entity.SetIfNotNull(createDto.TextField, (entity) => entity.TextField =TestWebApp.Domain.EntityUniqueConstraintsRelatedForeignKeyMetadata.CreateTextField(createDto.TextField.NonNullValue<System.String>()));
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityExactlyOneFactoryBase : IEntityFactory<S
     private TestWebApp.Domain.SecondTestEntityExactlyOne ToEntity(SecondTestEntityExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityExactlyOne();
-        entity.Id = SecondTestEntityExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityExactlyOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityOneOrManyFactoryBase : IEntityFactory<Se
     private TestWebApp.Domain.SecondTestEntityOneOrMany ToEntity(SecondTestEntityOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityOneOrMany();
-        entity.Id = SecondTestEntityOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityOneOrManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsManyToManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsManyToManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityTwoRelationshipsManyToManyFactoryBase : 
     private TestWebApp.Domain.SecondTestEntityTwoRelationshipsManyToMany ToEntity(SecondTestEntityTwoRelationshipsManyToManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityTwoRelationshipsManyToMany();
-        entity.Id = SecondTestEntityTwoRelationshipsManyToManyMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityTwoRelationshipsManyToManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityTwoRelationshipsManyToManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsOneToManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsOneToManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityTwoRelationshipsOneToManyFactoryBase : I
     private TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToMany ToEntity(SecondTestEntityTwoRelationshipsOneToManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToMany();
-        entity.Id = SecondTestEntityTwoRelationshipsOneToManyMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityTwoRelationshipsOneToManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsOneToOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityTwoRelationshipsOneToOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityTwoRelationshipsOneToOneFactoryBase : IE
     private TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToOne ToEntity(SecondTestEntityTwoRelationshipsOneToOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToOne();
-        entity.Id = SecondTestEntityTwoRelationshipsOneToOneMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityTwoRelationshipsOneToOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityTwoRelationshipsOneToOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityZeroOrManyFactoryBase : IEntityFactory<S
     private TestWebApp.Domain.SecondTestEntityZeroOrMany ToEntity(SecondTestEntityZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityZeroOrMany();
-        entity.Id = SecondTestEntityZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityZeroOrManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/SecondTestEntityZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class SecondTestEntityZeroOrOneFactoryBase : IEntityFactory<Se
     private TestWebApp.Domain.SecondTestEntityZeroOrOne ToEntity(SecondTestEntityZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.SecondTestEntityZeroOrOne();
-        entity.Id = SecondTestEntityZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = SecondTestEntityZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.SecondTestEntityZeroOrOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityExactlyOneFactoryBase : IEntityFactory<TestEnt
     private TestWebApp.Domain.TestEntityExactlyOne ToEntity(TestEntityExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityExactlyOne();
-        entity.Id = TestEntityExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityExactlyOneMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityExactlyOneToOneOrManyFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityExactlyOneToOneOrMany ToEntity(TestEntityExactlyOneToOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityExactlyOneToOneOrMany();
-        entity.Id = TestEntityExactlyOneToOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityExactlyOneToOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityExactlyOneToOneOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityExactlyOneToZeroOrManyFactoryBase : IEntityFac
     private TestWebApp.Domain.TestEntityExactlyOneToZeroOrMany ToEntity(TestEntityExactlyOneToZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityExactlyOneToZeroOrMany();
-        entity.Id = TestEntityExactlyOneToZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityExactlyOneToZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityExactlyOneToZeroOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityExactlyOneToZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityExactlyOneToZeroOrOneFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityExactlyOneToZeroOrOne ToEntity(TestEntityExactlyOneToZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityExactlyOneToZeroOrOne();
-        entity.Id = TestEntityExactlyOneToZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityExactlyOneToZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityExactlyOneToZeroOrOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityForTypesFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityForTypesFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityForTypesFactoryBase : IEntityFactory<TestEntit
     private TestWebApp.Domain.TestEntityForTypes ToEntity(TestEntityForTypesCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityForTypes();
-        entity.Id = TestEntityForTypesMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityForTypesMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityForTypesMetadata.CreateTextTestField(createDto.TextTestField);
         entity.SetIfNotNull(createDto.EnumerationTestField, (entity) => entity.EnumerationTestField =TestWebApp.Domain.TestEntityForTypesMetadata.CreateEnumerationTestField(createDto.EnumerationTestField.NonNullValue<System.Int32>()));
         entity.NumberTestField = TestWebApp.Domain.TestEntityForTypesMetadata.CreateNumberTestField(createDto.NumberTestField);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityForUniqueConstraintsFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityForUniqueConstraintsFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityForUniqueConstraintsFactoryBase : IEntityFacto
     private TestWebApp.Domain.TestEntityForUniqueConstraints ToEntity(TestEntityForUniqueConstraintsCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityForUniqueConstraints();
-        entity.Id = TestEntityForUniqueConstraintsMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityForUniqueConstraintsMetadata.CreateId(createDto.Id);
         entity.TextField = TestWebApp.Domain.TestEntityForUniqueConstraintsMetadata.CreateTextField(createDto.TextField);
         entity.NumberField = TestWebApp.Domain.TestEntityForUniqueConstraintsMetadata.CreateNumberField(createDto.NumberField);
         entity.UniqueNumberField = TestWebApp.Domain.TestEntityForUniqueConstraintsMetadata.CreateUniqueNumberField(createDto.UniqueNumberField);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityLocalizationFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityLocalizationFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityLocalizationFactoryBase : IEntityFactory<TestE
     private TestWebApp.Domain.TestEntityLocalization ToEntity(TestEntityLocalizationCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityLocalization();
-        entity.Id = TestEntityLocalizationMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityLocalizationMetadata.CreateId(createDto.Id);
         entity.TextFieldToLocalize = TestWebApp.Domain.TestEntityLocalizationMetadata.CreateTextFieldToLocalize(createDto.TextFieldToLocalize);
         entity.NumberField = TestWebApp.Domain.TestEntityLocalizationMetadata.CreateNumberField(createDto.NumberField);
         return entity;

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityOneOrManyFactoryBase : IEntityFactory<TestEnti
     private TestWebApp.Domain.TestEntityOneOrMany ToEntity(TestEntityOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOneOrMany();
-        entity.Id = TestEntityOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOneOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityOneOrManyToExactlyOneFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityOneOrManyToExactlyOne ToEntity(TestEntityOneOrManyToExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOneOrManyToExactlyOne();
-        entity.Id = TestEntityOneOrManyToExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOneOrManyToExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityOneOrManyToExactlyOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityOneOrManyToZeroOrManyFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityOneOrManyToZeroOrMany ToEntity(TestEntityOneOrManyToZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOneOrManyToZeroOrMany();
-        entity.Id = TestEntityOneOrManyToZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOneOrManyToZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOneOrManyToZeroOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOneOrManyToZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityOneOrManyToZeroOrOneFactoryBase : IEntityFacto
     private TestWebApp.Domain.TestEntityOneOrManyToZeroOrOne ToEntity(TestEntityOneOrManyToZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOneOrManyToZeroOrOne();
-        entity.Id = TestEntityOneOrManyToZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOneOrManyToZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityOneOrManyToZeroOrOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipExactlyOneFactory.g.cs
@@ -54,7 +54,7 @@ internal abstract class TestEntityOwnedRelationshipExactlyOneFactoryBase : IEnti
     private TestWebApp.Domain.TestEntityOwnedRelationshipExactlyOne ToEntity(TestEntityOwnedRelationshipExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOwnedRelationshipExactlyOne();
-        entity.Id = TestEntityOwnedRelationshipExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOwnedRelationshipExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOwnedRelationshipExactlyOneMetadata.CreateTextTestField(createDto.TextTestField);
         if (createDto.SecondTestEntityOwnedRelationshipExactlyOne is not null)
         {

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipOneOrManyFactory.g.cs
@@ -54,7 +54,7 @@ internal abstract class TestEntityOwnedRelationshipOneOrManyFactoryBase : IEntit
     private TestWebApp.Domain.TestEntityOwnedRelationshipOneOrMany ToEntity(TestEntityOwnedRelationshipOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOwnedRelationshipOneOrMany();
-        entity.Id = TestEntityOwnedRelationshipOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOwnedRelationshipOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOwnedRelationshipOneOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         createDto.SecondTestEntityOwnedRelationshipOneOrManies.ForEach(dto => entity.CreateRefToSecondTestEntityOwnedRelationshipOneOrManies(SecondTestEntityOwnedRelationshipOneOrManyFactory.CreateEntity(dto)));
         return entity;

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrManyFactory.g.cs
@@ -54,7 +54,7 @@ internal abstract class TestEntityOwnedRelationshipZeroOrManyFactoryBase : IEnti
     private TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrMany ToEntity(TestEntityOwnedRelationshipZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrMany();
-        entity.Id = TestEntityOwnedRelationshipZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOwnedRelationshipZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         createDto.SecondTestEntityOwnedRelationshipZeroOrManies.ForEach(dto => entity.CreateRefToSecondTestEntityOwnedRelationshipZeroOrManies(SecondTestEntityOwnedRelationshipZeroOrManyFactory.CreateEntity(dto)));
         return entity;

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrOneFactory.g.cs
@@ -54,7 +54,7 @@ internal abstract class TestEntityOwnedRelationshipZeroOrOneFactoryBase : IEntit
     private TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrOne ToEntity(TestEntityOwnedRelationshipZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrOne();
-        entity.Id = TestEntityOwnedRelationshipZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityOwnedRelationshipZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityOwnedRelationshipZeroOrOneMetadata.CreateTextTestField(createDto.TextTestField);
         if (createDto.SecondTestEntityOwnedRelationshipZeroOrOne is not null)
         {

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsManyToManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsManyToManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityTwoRelationshipsManyToManyFactoryBase : IEntit
     private TestWebApp.Domain.TestEntityTwoRelationshipsManyToMany ToEntity(TestEntityTwoRelationshipsManyToManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityTwoRelationshipsManyToMany();
-        entity.Id = TestEntityTwoRelationshipsManyToManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityTwoRelationshipsManyToManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityTwoRelationshipsManyToManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsOneToManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsOneToManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityTwoRelationshipsOneToManyFactoryBase : IEntity
     private TestWebApp.Domain.TestEntityTwoRelationshipsOneToMany ToEntity(TestEntityTwoRelationshipsOneToManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityTwoRelationshipsOneToMany();
-        entity.Id = TestEntityTwoRelationshipsOneToManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityTwoRelationshipsOneToManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityTwoRelationshipsOneToManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsOneToOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityTwoRelationshipsOneToOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityTwoRelationshipsOneToOneFactoryBase : IEntityF
     private TestWebApp.Domain.TestEntityTwoRelationshipsOneToOne ToEntity(TestEntityTwoRelationshipsOneToOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityTwoRelationshipsOneToOne();
-        entity.Id = TestEntityTwoRelationshipsOneToOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityTwoRelationshipsOneToOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityTwoRelationshipsOneToOneMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrManyFactoryBase : IEntityFactory<TestEnt
     private TestWebApp.Domain.TestEntityZeroOrMany ToEntity(TestEntityZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrMany();
-        entity.Id = TestEntityZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityZeroOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrManyToExactlyOneFactoryBase : IEntityFac
     private TestWebApp.Domain.TestEntityZeroOrManyToExactlyOne ToEntity(TestEntityZeroOrManyToExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrManyToExactlyOne();
-        entity.Id = TestEntityZeroOrManyToExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrManyToExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityZeroOrManyToExactlyOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrManyToOneOrManyFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityZeroOrManyToOneOrMany ToEntity(TestEntityZeroOrManyToOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrManyToOneOrMany();
-        entity.Id = TestEntityZeroOrManyToOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrManyToOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityZeroOrManyToOneOrManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrManyToZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrManyToZeroOrOneFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityZeroOrManyToZeroOrOne ToEntity(TestEntityZeroOrManyToZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrManyToZeroOrOne();
-        entity.Id = TestEntityZeroOrManyToZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrManyToZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.TestEntityZeroOrManyToZeroOrOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrOneFactoryBase : IEntityFactory<TestEnti
     private TestWebApp.Domain.TestEntityZeroOrOne ToEntity(TestEntityZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrOne();
-        entity.Id = TestEntityZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityZeroOrOneMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrOneToExactlyOneFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityZeroOrOneToExactlyOne ToEntity(TestEntityZeroOrOneToExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrOneToExactlyOne();
-        entity.Id = TestEntityZeroOrOneToExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrOneToExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityZeroOrOneToExactlyOneMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrOneToOneOrManyFactoryBase : IEntityFacto
     private TestWebApp.Domain.TestEntityZeroOrOneToOneOrMany ToEntity(TestEntityZeroOrOneToOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrOneToOneOrMany();
-        entity.Id = TestEntityZeroOrOneToOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrOneToOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityZeroOrOneToOneOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityZeroOrOneToZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class TestEntityZeroOrOneToZeroOrManyFactoryBase : IEntityFact
     private TestWebApp.Domain.TestEntityZeroOrOneToZeroOrMany ToEntity(TestEntityZeroOrOneToZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.TestEntityZeroOrOneToZeroOrMany();
-        entity.Id = TestEntityZeroOrOneToZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = TestEntityZeroOrOneToZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.TestEntityZeroOrOneToZeroOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityExactlyOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class ThirdTestEntityExactlyOneFactoryBase : IEntityFactory<Th
     private TestWebApp.Domain.ThirdTestEntityExactlyOne ToEntity(ThirdTestEntityExactlyOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.ThirdTestEntityExactlyOne();
-        entity.Id = ThirdTestEntityExactlyOneMetadata.CreateId(createDto.Id!);
+        entity.Id = ThirdTestEntityExactlyOneMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.ThirdTestEntityExactlyOneMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityOneOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class ThirdTestEntityOneOrManyFactoryBase : IEntityFactory<Thi
     private TestWebApp.Domain.ThirdTestEntityOneOrMany ToEntity(ThirdTestEntityOneOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.ThirdTestEntityOneOrMany();
-        entity.Id = ThirdTestEntityOneOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = ThirdTestEntityOneOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField = TestWebApp.Domain.ThirdTestEntityOneOrManyMetadata.CreateTextTestField(createDto.TextTestField);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityZeroOrManyFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class ThirdTestEntityZeroOrManyFactoryBase : IEntityFactory<Th
     private TestWebApp.Domain.ThirdTestEntityZeroOrMany ToEntity(ThirdTestEntityZeroOrManyCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.ThirdTestEntityZeroOrMany();
-        entity.Id = ThirdTestEntityZeroOrManyMetadata.CreateId(createDto.Id!);
+        entity.Id = ThirdTestEntityZeroOrManyMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.ThirdTestEntityZeroOrManyMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/ThirdTestEntityZeroOrOneFactory.g.cs
@@ -51,7 +51,7 @@ internal abstract class ThirdTestEntityZeroOrOneFactoryBase : IEntityFactory<Thi
     private TestWebApp.Domain.ThirdTestEntityZeroOrOne ToEntity(ThirdTestEntityZeroOrOneCreateDto createDto)
     {
         var entity = new TestWebApp.Domain.ThirdTestEntityZeroOrOne();
-        entity.Id = ThirdTestEntityZeroOrOneMetadata.CreateId(createDto.Id!);
+        entity.Id = ThirdTestEntityZeroOrOneMetadata.CreateId(createDto.Id);
         entity.TextTestField2 = TestWebApp.Domain.ThirdTestEntityZeroOrOneMetadata.CreateTextTestField2(createDto.TextTestField2);
         return entity;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EntityUniqueConstraintsRelatedForeignKeysController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EntityUniqueConstraintsRelatedForeignKeysController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class EntityUniqueConstraintsRelatedForeignKeysControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateEntityUniqueConstraintsRelatedForeignKeyCommand(entityUniqueConstraintsRelatedForeignKey, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class EntityUniqueConstraintsRelatedForeignKeysControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class EntityUniqueConstraintsRelatedForeignKeysControlle
     {
         if (!ModelState.IsValid || entityUniqueConstraintsRelatedForeignKey is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EntityUniqueConstraintsWithForeignKeysController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/EntityUniqueConstraintsWithForeignKeysController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class EntityUniqueConstraintsWithForeignKeysControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateEntityUniqueConstraintsWithForeignKeyCommand(entityUniqueConstraintsWithForeignKey, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class EntityUniqueConstraintsWithForeignKeysControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class EntityUniqueConstraintsWithForeignKeysControllerBa
     {
         if (!ModelState.IsValid || entityUniqueConstraintsWithForeignKey is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityExactlyOnesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityExactlyOneCommand(secondTestEntityExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityExactlyOnesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityExactlyOnesControllerBase : ODataC
     {
         if (!ModelState.IsValid || secondTestEntityExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityOneOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityOneOrManyCommand(secondTestEntityOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityOneOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityOneOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid || secondTestEntityOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsManyToManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsManyToManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsManyToManiesContro
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityTwoRelationshipsManyToManyCommand(secondTestEntityTwoRelationshipsManyToMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsManyToManiesContro
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsManyToManiesContro
     {
         if (!ModelState.IsValid || secondTestEntityTwoRelationshipsManyToMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsOneToManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsOneToManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToManiesControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityTwoRelationshipsOneToManyCommand(secondTestEntityTwoRelationshipsOneToMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToManiesControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToManiesControl
     {
         if (!ModelState.IsValid || secondTestEntityTwoRelationshipsOneToMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsOneToOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityTwoRelationshipsOneToOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToOnesControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityTwoRelationshipsOneToOneCommand(secondTestEntityTwoRelationshipsOneToOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToOnesControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityTwoRelationshipsOneToOnesControlle
     {
         if (!ModelState.IsValid || secondTestEntityTwoRelationshipsOneToOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityZeroOrManiesControllerBase : OData
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityZeroOrManyCommand(secondTestEntityZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityZeroOrManiesControllerBase : OData
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityZeroOrManiesControllerBase : OData
     {
         if (!ModelState.IsValid || secondTestEntityZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/SecondTestEntityZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class SecondTestEntityZeroOrOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateSecondTestEntityZeroOrOneCommand(secondTestEntityZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class SecondTestEntityZeroOrOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class SecondTestEntityZeroOrOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid || secondTestEntityZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityExactlyOneToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityExactlyOneToOneOrManyCommand(testEntityExactlyOneToOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityExactlyOneToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityExactlyOneToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid || testEntityExactlyOneToOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrManiesControllerBase :
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityExactlyOneToZeroOrManyCommand(testEntityExactlyOneToZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrManiesControllerBase :
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrManiesControllerBase :
     {
         if (!ModelState.IsValid || testEntityExactlyOneToZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOneToZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityExactlyOneToZeroOrOneCommand(testEntityExactlyOneToZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityExactlyOneToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid || testEntityExactlyOneToZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityExactlyOnesControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityExactlyOneCommand(testEntityExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityExactlyOnesControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityExactlyOnesControllerBase : ODataControl
     {
         if (!ModelState.IsValid || testEntityExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForAutoNumberUsagesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForAutoNumberUsagesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityForAutoNumberUsagesControllerBase : ODat
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityForAutoNumberUsagesCommand(testEntityForAutoNumberUsages, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityForAutoNumberUsagesControllerBase : ODat
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityForAutoNumberUsagesControllerBase : ODat
     {
         if (!ModelState.IsValid || testEntityForAutoNumberUsages is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForTypesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForTypesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityForTypesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityForTypesCommand(testEntityForTypes, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityForTypesControllerBase : ODataController
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityForTypesControllerBase : ODataController
     {
         if (!ModelState.IsValid || testEntityForTypes is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForUniqueConstraintsController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityForUniqueConstraintsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityForUniqueConstraintsControllerBase : ODa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityForUniqueConstraintsCommand(testEntityForUniqueConstraints, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityForUniqueConstraintsControllerBase : ODa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityForUniqueConstraintsControllerBase : ODa
     {
         if (!ModelState.IsValid || testEntityForUniqueConstraints is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityLocalizationsController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityLocalizationsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityLocalizationsControllerBase : ODataContr
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityLocalizationCommand(testEntityLocalization, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityLocalizationsControllerBase : ODataContr
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityLocalizationsControllerBase : ODataContr
     {
         if (!ModelState.IsValid || testEntityLocalization is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityLocalizationsController/Translations.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityLocalizationsController/Translations.g.cs
@@ -35,7 +35,7 @@ public abstract partial class TestEntityLocalizationsControllerBase
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
         var etag = (await _mediator.Send(new GetTestEntityLocalizationByIdQuery(Nox.Types.CultureCode.From(cultureCode), key))).Select(e=>e.Etag).SingleOrDefault();
         

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOneOrManiesControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOneOrManyCommand(testEntityOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOneOrManiesControllerBase : ODataControl
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOneOrManiesControllerBase : ODataControl
     {
         if (!ModelState.IsValid || testEntityOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOneOrManyToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOneOrManyToExactlyOneCommand(testEntityOneOrManyToExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOneOrManyToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOneOrManyToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid || testEntityOneOrManyToExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOneOrManyToZeroOrManyCommand(testEntityOneOrManyToZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid || testEntityOneOrManyToZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOneOrManyToZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrOnesControllerBase : OD
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOneOrManyToZeroOrOneCommand(testEntityOneOrManyToZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrOnesControllerBase : OD
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOneOrManyToZeroOrOnesControllerBase : OD
     {
         if (!ModelState.IsValid || testEntityOneOrManyToZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOnesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOwnedRelationshipExactlyOneCommand(testEntityOwnedRelationshipExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOnesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOnesControllerBa
     {
         if (!ModelState.IsValid || testEntityOwnedRelationshipExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManiesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOwnedRelationshipOneOrManyCommand(testEntityOwnedRelationshipOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManiesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManiesControllerBa
     {
         if (!ModelState.IsValid || testEntityOwnedRelationshipOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManiesControllerB
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOwnedRelationshipZeroOrManyCommand(testEntityOwnedRelationshipZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManiesControllerB
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManiesControllerB
     {
         if (!ModelState.IsValid || testEntityOwnedRelationshipZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityOwnedRelationshipZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOnesControllerBas
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityOwnedRelationshipZeroOrOneCommand(testEntityOwnedRelationshipZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOnesControllerBas
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOnesControllerBas
     {
         if (!ModelState.IsValid || testEntityOwnedRelationshipZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsManyToManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsManyToManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityTwoRelationshipsManyToManiesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityTwoRelationshipsManyToManyCommand(testEntityTwoRelationshipsManyToMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityTwoRelationshipsManyToManiesControllerBa
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityTwoRelationshipsManyToManiesControllerBa
     {
         if (!ModelState.IsValid || testEntityTwoRelationshipsManyToMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsOneToManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsOneToManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToManiesControllerBas
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityTwoRelationshipsOneToManyCommand(testEntityTwoRelationshipsOneToMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToManiesControllerBas
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToManiesControllerBas
     {
         if (!ModelState.IsValid || testEntityTwoRelationshipsOneToMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsOneToOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityTwoRelationshipsOneToOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToOnesControllerBase 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityTwoRelationshipsOneToOneCommand(testEntityTwoRelationshipsOneToOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToOnesControllerBase 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityTwoRelationshipsOneToOnesControllerBase 
     {
         if (!ModelState.IsValid || testEntityTwoRelationshipsOneToOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityWithNuidsController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityWithNuidsController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityWithNuidsControllerBase : ODataControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityWithNuidCommand(testEntityWithNuid, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityWithNuidsControllerBase : ODataControlle
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityWithNuidsControllerBase : ODataControlle
     {
         if (!ModelState.IsValid || testEntityWithNuid is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrManiesControllerBase : ODataContro
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrManyCommand(testEntityZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrManiesControllerBase : ODataContro
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrManiesControllerBase : ODataContro
     {
         if (!ModelState.IsValid || testEntityZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrManyToExactlyOnesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrManyToExactlyOneCommand(testEntityZeroOrManyToExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrManyToExactlyOnesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrManyToExactlyOnesControllerBase : 
     {
         if (!ModelState.IsValid || testEntityZeroOrManyToExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrManyToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrManyToOneOrManyCommand(testEntityZeroOrManyToOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrManyToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrManyToOneOrManiesControllerBase : 
     {
         if (!ModelState.IsValid || testEntityZeroOrManyToOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrManyToZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrManyToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrManyToZeroOrOneCommand(testEntityZeroOrManyToZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrManyToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrManyToZeroOrOnesControllerBase : O
     {
         if (!ModelState.IsValid || testEntityZeroOrManyToZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrOneToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrOneToExactlyOneCommand(testEntityZeroOrOneToExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrOneToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrOneToExactlyOnesControllerBase : O
     {
         if (!ModelState.IsValid || testEntityZeroOrOneToExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrOneToOneOrManiesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrOneToOneOrManyCommand(testEntityZeroOrOneToOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrOneToOneOrManiesControllerBase : O
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrOneToOneOrManiesControllerBase : O
     {
         if (!ModelState.IsValid || testEntityZeroOrOneToOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOneToZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrOneToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrOneToZeroOrManyCommand(testEntityZeroOrOneToZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrOneToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrOneToZeroOrManiesControllerBase : 
     {
         if (!ModelState.IsValid || testEntityZeroOrOneToZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/TestEntityZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class TestEntityZeroOrOnesControllerBase : ODataControll
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateTestEntityZeroOrOneCommand(testEntityZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class TestEntityZeroOrOnesControllerBase : ODataControll
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class TestEntityZeroOrOnesControllerBase : ODataControll
     {
         if (!ModelState.IsValid || testEntityZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityExactlyOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityExactlyOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class ThirdTestEntityExactlyOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateThirdTestEntityExactlyOneCommand(thirdTestEntityExactlyOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class ThirdTestEntityExactlyOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class ThirdTestEntityExactlyOnesControllerBase : ODataCo
     {
         if (!ModelState.IsValid || thirdTestEntityExactlyOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityOneOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityOneOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class ThirdTestEntityOneOrManiesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateThirdTestEntityOneOrManyCommand(thirdTestEntityOneOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class ThirdTestEntityOneOrManiesControllerBase : ODataCo
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class ThirdTestEntityOneOrManiesControllerBase : ODataCo
     {
         if (!ModelState.IsValid || thirdTestEntityOneOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityZeroOrManiesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityZeroOrManiesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class ThirdTestEntityZeroOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateThirdTestEntityZeroOrManyCommand(thirdTestEntityZeroOrMany, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class ThirdTestEntityZeroOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class ThirdTestEntityZeroOrManiesControllerBase : ODataC
     {
         if (!ModelState.IsValid || thirdTestEntityZeroOrMany is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityZeroOrOnesController/Entity.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ThirdTestEntityZeroOrOnesController/Entity.g.cs
@@ -71,7 +71,7 @@ public abstract partial class ThirdTestEntityZeroOrOnesControllerBase : ODataCon
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var createdKey = await _mediator.Send(new CreateThirdTestEntityZeroOrOneCommand(thirdTestEntityZeroOrOne, _cultureCode));
@@ -85,7 +85,7 @@ public abstract partial class ThirdTestEntityZeroOrOnesControllerBase : ODataCon
     {
         if (!ModelState.IsValid)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var etag = Request.GetDecodedEtagHeader();
@@ -105,7 +105,7 @@ public abstract partial class ThirdTestEntityZeroOrOnesControllerBase : ODataCon
     {
         if (!ModelState.IsValid || thirdTestEntityZeroOrOne is null)
         {
-            return BadRequest(ModelState);
+            throw new Nox.Exceptions.BadRequestException(ModelState);
         }
 
         var updatedProperties = new Dictionary<string, dynamic>();

--- a/tests/Nox.Types.Tests/Types/Area/AreaTests.cs
+++ b/tests/Nox.Types.Tests/Types/Area/AreaTests.cs
@@ -42,7 +42,7 @@ public class AreaTests
         {
             var action = () => Area.From(12.5, new AreaTypeOptions { MaxValue = 10, Units = AreaTypeUnit.SquareMeter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -60,7 +60,7 @@ public class AreaTests
         {
             var action = () => Area.From(12.5, new AreaTypeOptions { MinValue = 15, Units = AreaTypeUnit.SquareMeter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -78,7 +78,7 @@ public class AreaTests
         {
             var action = () => Area.From(-12.5);
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -94,7 +94,7 @@ public class AreaTests
     {
         var action = () => Area.From(double.NaN);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value NaN is not allowed.") });
     }
@@ -104,7 +104,7 @@ public class AreaTests
     {
         var action = () => Area.From(double.PositiveInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -114,7 +114,7 @@ public class AreaTests
     {
         var action = () => Area.From(double.NegativeInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }

--- a/tests/Nox.Types.Tests/Types/Color/ColorTests.cs
+++ b/tests/Nox.Types.Tests/Types/Color/ColorTests.cs
@@ -180,7 +180,7 @@ public class ColorTests
     {
         Action comparison = () => Nox.Types.Color.From(color);
 
-        comparison.Should().Throw<TypeValidationException>();
+        comparison.Should().Throw<NoxTypeValidationException>();
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/Types/CountryCode2/CountryCode2Tests.cs
+++ b/tests/Nox.Types.Tests/Types/CountryCode2/CountryCode2Tests.cs
@@ -14,7 +14,7 @@ public class CountryCode2Tests
     [Fact]
     public void CountryCode2_Constructor_WithUnsupportedCountryCode2_ThrowsValidationException()
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
           Nox.Types.CountryCode2.From("ABC")
         );
 

--- a/tests/Nox.Types.Tests/Types/CountryCode3/CountryCode3Tests.cs
+++ b/tests/Nox.Types.Tests/Types/CountryCode3/CountryCode3Tests.cs
@@ -16,7 +16,7 @@ public class CountryCode3Tests
     [Fact]
     public void CreatingCountryCode3_UnsupportedCountryCode3_ThrowsValidationException()
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             Nox.Types.CountryCode3.From("ABC")
         );
 

--- a/tests/Nox.Types.Tests/Types/CountryNumber/CountryNumberTests.cs
+++ b/tests/Nox.Types.Tests/Types/CountryNumber/CountryNumberTests.cs
@@ -19,7 +19,7 @@ public class CountryNumberTests
     [InlineData(1000u)]
     public void CountryNumber_Constructor_WithUnallowedValue_ThrowsException(ushort value)
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             CountryNumber.From(value)
         );
 

--- a/tests/Nox.Types.Tests/Types/CultureCode/CultureCodeTests.cs
+++ b/tests/Nox.Types.Tests/Types/CultureCode/CultureCodeTests.cs
@@ -26,7 +26,7 @@ public class CultureCodeTests
     {
         
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => _ = CultureCode.From(cultureCode));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ = CultureCode.From(cultureCode));
 
         // Assert
         Assert.Equal($"Could not create a Nox CultureCode type with unsupported value '{cultureCode}'.", exception.Errors.First().ErrorMessage);

--- a/tests/Nox.Types.Tests/Types/CurrencyCode3/CurrencyCode3Tests.cs
+++ b/tests/Nox.Types.Tests/Types/CurrencyCode3/CurrencyCode3Tests.cs
@@ -18,7 +18,7 @@ public class CurrencyCode3Tests
     {
         var action = () => CurrencyCode3.From("ABC");
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox CurrencyCode3 type with unsupported value 'ABC'.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/CurrencyNumber/CurrencyNumberTests.cs
+++ b/tests/Nox.Types.Tests/Types/CurrencyNumber/CurrencyNumberTests.cs
@@ -18,7 +18,7 @@ public class CurrencyNumberTests
     {
         var action = () => CurrencyNumber.From(991);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox CurrencyNumber type with unsupported value '991'.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Date/DateTests.cs
+++ b/tests/Nox.Types.Tests/Types/Date/DateTests.cs
@@ -51,7 +51,7 @@ public class DateTests
 
         var action = () => Date.From(new DateOnly(2023, 07, 01), options);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Date type as value 07/01/2023 is greater than than the maximum specified value of 06/01/2023") });
     }
 
@@ -66,7 +66,7 @@ public class DateTests
 
         var action = () => Date.From(new DateOnly(2023, 03, 01), options);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Date type as value 03/01/2023 is less than than the minimum specified value of 04/01/2023") });
     }
 
@@ -81,7 +81,7 @@ public class DateTests
 
         var action = () => Date.From(2023, 07, 01, options);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Date type as value 07/01/2023 is greater than than the maximum specified value of 06/01/2023") });
     }
 
@@ -96,7 +96,7 @@ public class DateTests
 
         var action = () => Date.From(2023, 03, 01, options);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Date type as value 03/01/2023 is less than than the minimum specified value of 04/01/2023") });
     }
 

--- a/tests/Nox.Types.Tests/Types/DateTime/DateTimeTests.cs
+++ b/tests/Nox.Types.Tests/Types/DateTime/DateTimeTests.cs
@@ -21,7 +21,7 @@ public class DateTimeTests
         DateTimeTypeOptions dateTimeTypeOptions = new() { AllowFutureOnly = true };
         Action comparison = () => DateTime.From(new DateTimeOffset(2000, 01, 01, 0, 0, 0, 0, TimeSpan.Zero), dateTimeTypeOptions);
 
-        comparison.Should().Throw<TypeValidationException>();
+        comparison.Should().Throw<NoxTypeValidationException>();
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public class DateTimeTests
         DateTimeTypeOptions dateTimeTypeOptions = new() { MaxValue = new DateTimeOffset(2022, 01, 01, 0, 0, 0, 0, TimeSpan.Zero) };
         Action comparison = () => DateTime.From(new DateTimeOffset(2023, 01, 01, 0, 0, 0, 0, TimeSpan.Zero), dateTimeTypeOptions);
 
-        comparison.Should().Throw<TypeValidationException>();
+        comparison.Should().Throw<NoxTypeValidationException>();
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/Types/DateTimeDuration/DateTimeDurationTests.cs
+++ b/tests/Nox.Types.Tests/Types/DateTimeDuration/DateTimeDurationTests.cs
@@ -181,7 +181,7 @@ public class DateTimeDurationTests
             TimeUnit = TimeUnit.Day,
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DateTimeDuration type as value 10.00:02:01 is less than than the minimum specified value of 10.12:00:00") });
     }
 
@@ -194,7 +194,7 @@ public class DateTimeDurationTests
             TimeUnit = TimeUnit.Day,
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DateTimeDuration type as value 10.12:02:01 is greater than than the maximum specified value of 10.12:00:00") });
     }
 
@@ -208,7 +208,7 @@ public class DateTimeDurationTests
             TimeUnit = TimeUnit.CustomFormat,
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DateTimeDuration type as value 10.00:02:01 is less than than the minimum specified value of 10.12:00:00") });
     }
 
@@ -221,7 +221,7 @@ public class DateTimeDurationTests
             TimeUnit = TimeUnit.CustomFormat,
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DateTimeDuration type as value 10.12:02:01 is greater than than the maximum specified value of 10.12:00:00") });
     }
 

--- a/tests/Nox.Types.Tests/Types/DateTimeRange/DateTimeRangeTests.cs
+++ b/tests/Nox.Types.Tests/Types/DateTimeRange/DateTimeRangeTests.cs
@@ -67,7 +67,7 @@ public class DateTimeRangeTests
 
             var action = () => DateTimeRange.From(start, end);
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DateTimeRange type with Start value {expectedStartStringOutput} and End value {expectedEndStringOutput} as start of the time range must be the same or before the end of the time range.") });
         }
 
@@ -88,7 +88,7 @@ public class DateTimeRangeTests
                 new DateTimeRangeTypeOptions { MinStartValue = new DateTimeOffset(2025, 01, 01, 0, 0, 0, 0, TimeSpan.Zero)}
             );
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Start", $"Could not create a Nox DateTimeRange type as Start value {expectedEndStringOutput} is less than than the minimum specified value of 01/01/2025 00:00:00 +00:00.") });
         }
 
@@ -109,7 +109,7 @@ public class DateTimeRangeTests
                 new DateTimeRangeTypeOptions { MaxEndValue = new DateTimeOffset(2025, 01, 01, 0, 0, 0, 0, TimeSpan.Zero) }
             );
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("End", $"Could not create a Nox DateTimeRange type as End value {expectedEndStringOutput} is greater than than the maximum specified value of 01/01/2025 00:00:00 +00:00.") });
         }
 

--- a/tests/Nox.Types.Tests/Types/DateTimeSchedule/DateTimeScheduleTests.cs
+++ b/tests/Nox.Types.Tests/Types/DateTimeSchedule/DateTimeScheduleTests.cs
@@ -65,7 +65,7 @@ public class DateTimeScheduleTests
     {
         Action comparison = () => DateTimeSchedule.From(value);
 
-        comparison.Should().Throw<TypeValidationException>();
+        comparison.Should().Throw<NoxTypeValidationException>();
     }
 
     [Theory]

--- a/tests/Nox.Types.Tests/Types/DayOfWeek/DayOfWeekTests.cs
+++ b/tests/Nox.Types.Tests/Types/DayOfWeek/DayOfWeekTests.cs
@@ -24,7 +24,7 @@ public class DayOfWeekTests
         var action = () => DayOfWeek.From(value);
 
         // Assert
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DayOfWeek type a value {value} is greater than the maximum specified value of 6") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox DayOfWeek type a value {value} is greater than the maximum specified value of 6") });
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/Types/Distance/DistanceTests.cs
+++ b/tests/Nox.Types.Tests/Types/Distance/DistanceTests.cs
@@ -43,7 +43,7 @@ public class DistanceTests
             var action = () =>
                 Distance.From(7.5, new DistanceTypeOptions { MaxValue = 5, Units = DistanceTypeUnit.Kilometer });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -62,7 +62,7 @@ public class DistanceTests
             var action = () =>
                 Distance.From(7.5, new DistanceTypeOptions { MinValue = 10, Units = DistanceTypeUnit.Kilometer });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -78,7 +78,7 @@ public class DistanceTests
     {
         var action = () => Distance.From(-100);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox Distance type as negative distance value -100 is not allowed.") });
     }
@@ -88,7 +88,7 @@ public class DistanceTests
     {
         var action = () => Distance.From(double.NaN);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value NaN is not allowed.") });
     }
@@ -98,7 +98,7 @@ public class DistanceTests
     {
         var action = () => Distance.From(double.PositiveInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -108,7 +108,7 @@ public class DistanceTests
     {
         var action = () => Distance.From(double.NegativeInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -148,7 +148,7 @@ public class DistanceTests
             var action = () => Distance.From(origin, destination,
                 new DistanceTypeOptions { MaxValue = 100, Units = DistanceTypeUnit.Kilometer });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -170,7 +170,7 @@ public class DistanceTests
             var action = () => Distance.From(origin, destination,
                 new DistanceTypeOptions { MinValue = 150, Units = DistanceTypeUnit.Kilometer });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",

--- a/tests/Nox.Types.Tests/Types/Email/EmailTests.cs
+++ b/tests/Nox.Types.Tests/Types/Email/EmailTests.cs
@@ -17,7 +17,7 @@ public class EmailTests
     {
         var testEmail = "It's a test designed to provoke an emotional response - Holden";
 
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Email.From(testEmail)
         );
     }

--- a/tests/Nox.Types.Tests/Types/Enumeration/EnumerationTests.cs
+++ b/tests/Nox.Types.Tests/Types/Enumeration/EnumerationTests.cs
@@ -62,7 +62,7 @@ public class EnumerationTests
         var action = () => Enumeration.From(42, _options);
 
         // Assert 
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(
             new[] { new ValidationFailure("Value", "No enumerator exists with an Id of '42'") });
     }
 
@@ -72,7 +72,7 @@ public class EnumerationTests
         var action = () => Enumeration.From("Option 42", _options);
 
         // Assert 
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(
             new[] { new ValidationFailure("Value", "No enumerator exists with an Description of 'Option 42'.") });
 
     }

--- a/tests/Nox.Types.Tests/Types/File/FileTests.cs
+++ b/tests/Nox.Types.Tests/Types/File/FileTests.cs
@@ -37,7 +37,7 @@ public class FileTests
     {
         var action = () => File.From(url!, "MyFile", 512);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox File type with an empty Url.") });
     }
 
@@ -46,7 +46,7 @@ public class FileTests
     {
         var action = () => File.From($"https://www.example.com/{new string('a', 2050)}/file1.pdf", "File1", 100);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox File type with an Url length greater than max allowed length of 2083.") });
     }
 
@@ -55,7 +55,7 @@ public class FileTests
     {
         var action = () => File.From("test", "MyFile", 512);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox File type with an invalid Url 'test'.") });
     }
 
@@ -71,7 +71,7 @@ public class FileTests
                 SupportedFileFormats = new List<FileFormatType> { FileFormatType.Pdf, FileFormatType.Docx }
             });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", $"Could not create a Nox File type with a file having an unsupported extension '{expected}'.") });
     }
 
@@ -83,7 +83,7 @@ public class FileTests
     {
         var action = () => File.From("https://example.com/myfile.pdf", prettyName!, 512);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("PrettyName", "Could not create a Nox File type with an empty PrettyName.") });
     }
 
@@ -92,7 +92,7 @@ public class FileTests
     {
         var action = () => File.From("https://example.com/myfile.pdf", new string('a', 512), 100);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("PrettyName", "Could not create a Nox File type with a PrettyName length greater than max allowed length of 511.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Formula/FormulaTests.cs
+++ b/tests/Nox.Types.Tests/Types/Formula/FormulaTests.cs
@@ -51,7 +51,7 @@ public class FormulaTests
             Returns = FormulaReturnType.@bool,
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Formula type as expression value {expression} contains invalid sequence of brackets.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Guid/GuidTests.cs
+++ b/tests/Nox.Types.Tests/Types/Guid/GuidTests.cs
@@ -44,7 +44,7 @@ public class GuidTests
 
         var act = () => Guid.From(emptyGuid);
 
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
             {
                 new ValidationFailure("Value",
@@ -57,7 +57,7 @@ public class GuidTests
     {
         var act = () => Guid.From(System.Guid.Empty);
 
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
             {
                 new ValidationFailure("Value",

--- a/tests/Nox.Types.Tests/Types/Html/HtmlTests.cs
+++ b/tests/Nox.Types.Tests/Types/Html/HtmlTests.cs
@@ -23,6 +23,6 @@ public class HtmlTests
     [InlineData("plain text")]
     public void Html_Constructor_WithInvalidInput_ThrowsValidationException(string badHtmlString)
     {
-        Assert.Throws<TypeValidationException>(() => Html.From(badHtmlString));
+        Assert.Throws<NoxTypeValidationException>(() => Html.From(badHtmlString));
     }
 }

--- a/tests/Nox.Types.Tests/Types/Image/ImageTests.cs
+++ b/tests/Nox.Types.Tests/Types/Image/ImageTests.cs
@@ -25,7 +25,7 @@ public class ImageTests
         var action = () => Image.From("", "Image1", 100);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox Image type with an empty Url.") });
     }
 
@@ -36,7 +36,7 @@ public class ImageTests
         var action = () => Image.From($"https://www.example.com/{new string('a', 2050)}/image.jpg", "Image1", 100);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox Image type with an Url length greater than max allowed length of 2083.") });
     }
 
@@ -47,7 +47,7 @@ public class ImageTests
         var action = () => Image.From("https://example.com/image.jpg", "", 100);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("PrettyName", "Could not create a Nox Image type with an empty PrettyName.") });
     }
 
@@ -58,7 +58,7 @@ public class ImageTests
         var action = () => Image.From("https://example.com/image.jpg", new string('a', 512), 100);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("PrettyName", "Could not create a Nox Image type with a PrettyName length greater than max allowed length of 511.") });
     }
 
@@ -69,7 +69,7 @@ public class ImageTests
         var action = () => Image.From("https://example.com/image.jpg", "Image1", 0);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("SizeInBytes", "Could not create a Nox Image type with a Size of 0.") });
     }
 
@@ -81,7 +81,7 @@ public class ImageTests
         var action = () => Image.From(url, prettyName, size);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", $"Could not create a Nox Image type with an image having an unsupported extension '{url}'.") });
     }
 
@@ -92,7 +92,7 @@ public class ImageTests
         var action = () => Image.From("invalid url", "Image1", 100);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox Image type with an invalid Url 'invalid url'.") });
     }
 
@@ -109,7 +109,7 @@ public class ImageTests
         var action = () => Image.From("https://example.com/image.png", "Image1", 100, imageTypeOptions);
 
         // Assert
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Url", "Could not create a Nox Image type with an image having an unsupported extension 'https://example.com/image.png'.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/InternetDomain/InternetDomainTests.cs
+++ b/tests/Nox.Types.Tests/Types/InternetDomain/InternetDomainTests.cs
@@ -26,7 +26,7 @@ public class InternetDomainTests
     public void InternetDomain_WithNullOrEmptyDomain_ShouldBeInvalid(string? invalidDomain)
     {
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException> (() => _ = InternetDomain.From(invalidDomain!));
+        var exception = Assert.Throws<NoxTypeValidationException> (() => _ = InternetDomain.From(invalidDomain!));
 
         // Assert
         Assert.NotNull(exception);
@@ -44,7 +44,7 @@ public class InternetDomainTests
     public void InternetDomain_WithInvalidDomain_ShouldBeInvalid(string invalidDomain)
     {
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => _ = InternetDomain.From(invalidDomain));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ = InternetDomain.From(invalidDomain));
 
         // Assert
         Assert.NotNull(exception);

--- a/tests/Nox.Types.Tests/Types/IpAddress/IpAddressTests.cs
+++ b/tests/Nox.Types.Tests/Types/IpAddress/IpAddressTests.cs
@@ -45,7 +45,7 @@ public class IpAddressTests
     [InlineData("192.168.1.")]  //  missing octets with trailing dot
     public void IpAddress_Constructor_WithInvalidIPv4Value_ThrowsException(string ipV4Value)
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             IpAddress.From(ipV4Value)
         );
 
@@ -81,7 +81,7 @@ public class IpAddressTests
     [InlineData("gggg:0db8::1")]                                //  invalid characters
     public void IpAddress_Constructor_WithInvalidIPv6Value_ThrowsException(string ipV6Value)
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             IpAddress.From(ipV6Value)
         );
 
@@ -92,7 +92,7 @@ public class IpAddressTests
     public void IpAddress_Constructor_WithVeryLargeInvalidIPv6Value_ThrowsException()
     {
         var ipV6Value = "2001:0db8:85a3:00000:0000:8a2e:0370:7334:2001:0db8:85a3:00000:0000:8a2e:0370:7334";
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             IpAddress.From(ipV6Value)
         );
 

--- a/tests/Nox.Types.Tests/Types/Json/JsonTest.cs
+++ b/tests/Nox.Types.Tests/Types/Json/JsonTest.cs
@@ -39,7 +39,7 @@ public class JsonTest
     public void Json_Constructor_InValidJson_ShouldThrowException(string jsonString)
     {
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => _ = Json.From(jsonString, new JsonTypeOptions { }));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ = Json.From(jsonString, new JsonTypeOptions { }));
 
         //Assert
         exception.Errors.First().ErrorMessage.Should().StartWith($"Could not create a Nox Json type with value {jsonString} due to JsonException");
@@ -114,7 +114,7 @@ public class JsonTest
         var jsonString = @"{""bad json]";
 
         // Assert
-        var exception = Assert.Throws<TypeValidationException>(() => _ = Json.From(jsonString));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ = Json.From(jsonString));
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/Types/JwtToken/JwtTokenTests.cs
+++ b/tests/Nox.Types.Tests/Types/JwtToken/JwtTokenTests.cs
@@ -32,7 +32,7 @@ public class JwtTokenTests
     {
         var action = () => JwtToken.From(value!);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox JWT Token type as the value cannot be null or empty.") });
     }
 
@@ -53,7 +53,7 @@ public class JwtTokenTests
     {
         var action = () => JwtToken.From(value);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox JWT Token type as value {value} does not have a valid JWT format.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/LanguageCode/LanguageCodeTests.cs
+++ b/tests/Nox.Types.Tests/Types/LanguageCode/LanguageCodeTests.cs
@@ -28,7 +28,7 @@ public class LanguageCodeTests
     {
         var action = () => LanguageCode.From("abc");
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox LanguageCode type with unsupported value 'abc'.") });
     }
 
@@ -89,7 +89,7 @@ public class LanguageCodeTests
     {
         var action = () => _languageCodes.Select(code => LanguageCode.From(code));
 
-        action.Should().NotThrow<TypeValidationException>();
+        action.Should().NotThrow<NoxTypeValidationException>();
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class LanguageCodeTests
         {
             var action = () => LanguageCode.From(nonLanguageCode);
             _output.WriteLine($"Testing invalid code {nonLanguageCode}..");
-            action.Should().Throw<TypeValidationException>();
+            action.Should().Throw<NoxTypeValidationException>();
         }
 
 

--- a/tests/Nox.Types.Tests/Types/LatLong/LatLongTests.cs
+++ b/tests/Nox.Types.Tests/Types/LatLong/LatLongTests.cs
@@ -16,7 +16,7 @@ public class LatLongTests
     [Fact]
     public void LatLong_Constructor_WithOutOfRangeLatitude_ThrowsValidationException()
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
           LatLong.From(100, 0)
         );
 
@@ -26,7 +26,7 @@ public class LatLongTests
     [Fact]
     public void LatLong_Constructor_WithOutOfRangeLongitude_ThrowsValidationException()
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
           LatLong.From(0, 200)
         );
 

--- a/tests/Nox.Types.Tests/Types/Length/LengthTests.cs
+++ b/tests/Nox.Types.Tests/Types/Length/LengthTests.cs
@@ -43,7 +43,7 @@ public class LengthTests
         {
             var action = () => Length.From(7.5, new LengthTypeOptions { MaxValue = 5, Units = LengthTypeUnit.Meter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -61,7 +61,7 @@ public class LengthTests
         {
             var action = () => Length.From(7.5, new LengthTypeOptions { MinValue = 10, Units = LengthTypeUnit.Meter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -77,7 +77,7 @@ public class LengthTests
     {
         var action = () => Length.From(-100);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox Length type as negative length value -100 is not allowed.") });
     }
@@ -87,7 +87,7 @@ public class LengthTests
     {
         var action = () => Length.From(double.NaN);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value NaN is not allowed.") });
     }
@@ -98,7 +98,7 @@ public class LengthTests
         var action = () => Length.From(double.PositiveInfinity);
 
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -108,7 +108,7 @@ public class LengthTests
     {
         var action = () => Length.From(double.NegativeInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
                 "Could not create a Nox type as value Infinity is not allowed.") });
     }

--- a/tests/Nox.Types.Tests/Types/MacAddress/MacAddressTests.cs
+++ b/tests/Nox.Types.Tests/Types/MacAddress/MacAddressTests.cs
@@ -51,7 +51,7 @@ public class MacAddressTests
     {
         var action = () => MacAddress.From(input);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox MAC Address type as value {input} is not a valid MAC Address.") });
     }
 
@@ -60,7 +60,7 @@ public class MacAddressTests
     {
         var action = () => MacAddress.From(0xFFFFFFFFFFFFF); // too many bytes
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox MAC Address type as value FFFFFFFFFFFFF is not a valid MAC Address.") });
     }
 
@@ -71,7 +71,7 @@ public class MacAddressTests
     {
         var action = () => MacAddress.From(input);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox MAC Address type as value {expectedOutput} is not a valid MAC Address.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Markdown/MarkdownTests.cs
+++ b/tests/Nox.Types.Tests/Types/Markdown/MarkdownTests.cs
@@ -57,7 +57,7 @@ public class MarkdownTests
         var maxLength = 3u;
         var fromAct = () => Markdown.From("long text", new MarkdownTypeOptions { MaxLength = maxLength });
 
-        fromAct.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
+        fromAct.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
             $"Could not create a Markdown type that is 9 characters long and longer than the maximum specified length of {maxLength}") });
     }
 }

--- a/tests/Nox.Types.Tests/Types/Month/MonthTests.cs
+++ b/tests/Nox.Types.Tests/Types/Month/MonthTests.cs
@@ -12,7 +12,7 @@ public class MonthTests
     public void Validate_InvalidValue_ReturnsValidationFailure(byte value)
     {
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => _ =  Month.From(value));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =  Month.From(value));
       
         // Assert
         exception.Errors.Should().Contain(e =>
@@ -32,7 +32,7 @@ public class MonthTests
     public void Validate_InvalidIntValue_ReturnsValidationFailure(int value)
     {
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => _ =  Month.From(value));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =  Month.From(value));
       
         // Assert
         exception.Errors.Should().Contain(e =>

--- a/tests/Nox.Types.Tests/Types/Number/NumberTests.cs
+++ b/tests/Nox.Types.Tests/Types/Number/NumberTests.cs
@@ -17,7 +17,7 @@ public class NumberTests
     {
         var testNumber = 3.14m;
 
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Number.From(testNumber, new NumberTypeOptions { MaxValue = 1 })
         );
     }
@@ -27,7 +27,7 @@ public class NumberTests
     {
         var testNumber = 3.14m;
 
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Number.From(testNumber, new NumberTypeOptions { MinValue = 42 })
         );
     }

--- a/tests/Nox.Types.Tests/Types/Password/PasswordTests.cs
+++ b/tests/Nox.Types.Tests/Types/Password/PasswordTests.cs
@@ -42,7 +42,7 @@ public class PasswordTests
     [InlineData("correct.password2.")]
     public void Password_From_DefaultOptions_ValidationFailed(string passwordText)
     {
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Password.From(passwordText)
         );
     }

--- a/tests/Nox.Types.Tests/Types/Percentage/PercentageTests.cs
+++ b/tests/Nox.Types.Tests/Types/Percentage/PercentageTests.cs
@@ -24,7 +24,7 @@ public class PercentageTests
 
             var action = () => Percentage.From(testPercentage);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Percentage type a value {testPercentage} is greater than than the maximum specified value of 1") });
         }
 
@@ -40,7 +40,7 @@ public class PercentageTests
 
             var action = () => Percentage.From(testPercentage);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Percentage type as value {testPercentage} is less than than the minimum specified value of 0") });
         }
         TestUtility.RunInInvariantCulture(Test);

--- a/tests/Nox.Types.Tests/Types/PhoneNumber/PhoneNumberTests.cs
+++ b/tests/Nox.Types.Tests/Types/PhoneNumber/PhoneNumberTests.cs
@@ -26,7 +26,7 @@ public class PhoneNumberTests
     {
         var action = () => PhoneNumber.From(value);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().ContainEquivalentOf(new ValidationFailure("Value", $"Could not create a Nox PhoneNumber type with invalid value '{value}'."));
     }
 }

--- a/tests/Nox.Types.Tests/Types/StreetAddress/StreetAddressTests.cs
+++ b/tests/Nox.Types.Tests/Types/StreetAddress/StreetAddressTests.cs
@@ -50,7 +50,7 @@ public class StreetAddressTests
             AddressLine1 = "Line 1"
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .WithMessage($"The Nox type validation failed with 1 error(s). PropertyName: PostalCode. Error: PostalCode '123456' for country with ID '{countryCode}' is invalid.")
             .And.Errors.Should().BeEquivalentTo(new[]
             {
@@ -91,7 +91,7 @@ public class StreetAddressTests
             CountryId = CountryCode.CH
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
             {
                 new ValidationFailure("StreetNumber", "Could not create a Nox StreetAddress type with a StreetNumber with length greater than max allowed length of 32."),
@@ -118,7 +118,7 @@ public class StreetAddressTests
             CountryId = CountryCode.GB
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .WithMessage("The Nox type validation failed with 1 error(s). PropertyName: AddressLine1. Error: Could not create a Nox StreetAddress type with an empty AddressLine1.")
             .And.Errors.Should().BeEquivalentTo(new[]
             {
@@ -140,7 +140,7 @@ public class StreetAddressTests
             CountryId = CountryCode.GB
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .WithMessage(@"The Nox type validation failed with 2 error(s). PropertyName: PostalCode. Error: PostalCode '' for country with ID 'GB' is invalid.
 PropertyName: PostalCode. Error: Could not create a Nox StreetAddress type with an empty PostalCode.")
             .And.Errors.Should().BeEquivalentTo(new[]
@@ -164,7 +164,7 @@ PropertyName: PostalCode. Error: Could not create a Nox StreetAddress type with 
             PostalCode = "KT16 0RS",
         });
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .WithMessage("The Nox type validation failed with 1 error(s). PropertyName: CountryId. Error: Country with ID '0' is invalid.")
             .And.Errors.Should().BeEquivalentTo(new[]
             {

--- a/tests/Nox.Types.Tests/Types/Temperature/TemperatureTests.cs
+++ b/tests/Nox.Types.Tests/Types/Temperature/TemperatureTests.cs
@@ -30,7 +30,7 @@ public class TemperatureTests
     {
         Action comparison = () => Temperature.From(double.NaN, TemperatureTypeUnit.Fahrenheit);
 
-        comparison.Should().Throw<TypeValidationException>();
+        comparison.Should().Throw<NoxTypeValidationException>();
     }
 
     [Fact]

--- a/tests/Nox.Types.Tests/Types/Text/TextTests.cs
+++ b/tests/Nox.Types.Tests/Types/Text/TextTests.cs
@@ -52,7 +52,7 @@ public class TextTests
     {
         var testString = "二兎を追う者は一兎をも得ず。"; // English translation: “Those who chase two hares won’t even catch one.”
 
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Text.From(testString, new TextTypeOptions { IsUnicode = false })
         );
 
@@ -63,7 +63,7 @@ public class TextTests
     {
         var testString = "It's a test designed to provoke an emotional response - Holden";
 
-        Assert.Throws<TypeValidationException>(() => _ =
+        Assert.Throws<NoxTypeValidationException>(() => _ =
             Text.From(testString, new TextTypeOptions { MaxLength = 3 })
         );
     }
@@ -73,7 +73,7 @@ public class TextTests
     {
         var testString = "It's a test designed to provoke an emotional response - Holden";
 
-        Assert.Throws<TypeValidationException>(() => _ = 
+        Assert.Throws<NoxTypeValidationException>(() => _ = 
             Text.From(testString, new TextTypeOptions { MinLength = 100 })
         );
     }

--- a/tests/Nox.Types.Tests/Types/Time/TimeTests.cs
+++ b/tests/Nox.Types.Tests/Types/Time/TimeTests.cs
@@ -104,7 +104,7 @@ public class TimeTests
             int minute = 0;
             int seconds = 0;
             int milliseconds = 100;
-            var exception = Assert.Throws<TypeValidationException>(() => _ =
+            var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
               Time.From(hour, minute, seconds, milliseconds, new TimeTypeOptions { MinTimeTicks = 25000000 })
             );
 
@@ -137,7 +137,7 @@ public class TimeTests
         void Test()
         {
             long ticks = 100;
-            var exception = Assert.Throws<TypeValidationException>(() => _ =
+            var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
               Time.From(ticks, new TimeTypeOptions { MinTimeTicks = 1000})
             );
 

--- a/tests/Nox.Types.Tests/Types/TimeZoneCode/TimeZoneCodeTests.cs
+++ b/tests/Nox.Types.Tests/Types/TimeZoneCode/TimeZoneCodeTests.cs
@@ -17,7 +17,7 @@ public class TimeZoneCodeTests
     [Fact]
     public void TimeZoneCode_Constructor_WithUnsupportedTimeZoneCode_ThrowsValidationException()
     {
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
           Nox.Types.TimeZoneCode.From("ABC")
         );
 

--- a/tests/Nox.Types.Tests/Types/TranslatedText/TranslatedTextTests.cs
+++ b/tests/Nox.Types.Tests/Types/TranslatedText/TranslatedTextTests.cs
@@ -33,7 +33,7 @@ public class TranslatedTextTests
         var translatedTestString = "إنه اختبار مصمم لإثارة استجابة عاطفية - هولدن";
         var arabicCultureCode = CultureCode.From("ar");
 
-        var exception =  Assert.Throws<TypeValidationException>(() => _ =
+        var exception =  Assert.Throws<NoxTypeValidationException>(() => _ =
             TranslatedText.From((arabicCultureCode, translatedTestString), new TranslatedTextTypeOptions { MaxLength = 15 })
         );
 
@@ -46,7 +46,7 @@ public class TranslatedTextTests
         var translatedTestString = "إنه اختبار مصمم لإثارة استجابة عاطفية - هولدن";
         var arabicCultureCode = CultureCode.From("ar");
 
-        var exception = Assert.Throws<TypeValidationException>(() => _ =
+        var exception = Assert.Throws<NoxTypeValidationException>(() => _ =
             TranslatedText.From((arabicCultureCode, translatedTestString), new TranslatedTextTypeOptions { MinLength = 100 })
             ); 
 

--- a/tests/Nox.Types.Tests/Types/Uri/UriTests.cs
+++ b/tests/Nox.Types.Tests/Types/Uri/UriTests.cs
@@ -88,7 +88,7 @@ public class UriTests
     {
         Action init = () => { var url = Uri.From(badUri); };
 
-        init.Should().Throw<TypeValidationException>();
+        init.Should().Throw<NoxTypeValidationException>();
     }
 
     [Fact]
@@ -98,6 +98,6 @@ public class UriTests
         
         Action init = () => { Uri.From(longUri); };
         
-        init.Should().Throw<TypeValidationException>();
+        init.Should().Throw<NoxTypeValidationException>();
     }
 }

--- a/tests/Nox.Types.Tests/Types/Url/UrlTests.cs
+++ b/tests/Nox.Types.Tests/Types/Url/UrlTests.cs
@@ -39,7 +39,7 @@ public class UrlTests
         var uri = new System.Uri(input);
         Action init = () => { Url.From(uri); };
 
-        init.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
+        init.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
             $"Could not create a Nox Url type as value {input} is not a valid Url.")
         });
     }
@@ -54,7 +54,7 @@ public class UrlTests
     {
         Action init = () => { Url.From(input); };
 
-        init.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
+        init.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
             $"Could not create a Nox Url type as value {input} is not a valid Url.")
         });
     }
@@ -65,7 +65,7 @@ public class UrlTests
         string longUrl =  $"file://{new('a', Url.MaxLength)}/";
         Action init = () => { Url.From(longUrl); };
 
-        init.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
+        init.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value",
             $"Could not create a Nox Url type as value {longUrl} is greater than the specified maximum of 2083")
         });
     }

--- a/tests/Nox.Types.Tests/Types/User/UserTests.cs
+++ b/tests/Nox.Types.Tests/Types/User/UserTests.cs
@@ -60,7 +60,7 @@ public class UserTests
     public void User_Constructor_SpecifyingMaxLength_WithLongerLengthInput_ThrowsValidationException()
     {
         var act = () => User.From("thequickbrownfoxjumpedoverthewoodenlog@iwgplc.com", new UserTypeOptions { MaxLength = 15 });
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.First().ErrorMessage.Should().Be("Could not create a Nox User type that is 49 characters long and longer than the maximum specified length of 15.");
     }
 
@@ -68,7 +68,7 @@ public class UserTests
     public void User_Constructor_SpecifyingMinLength_WithShorterLengthInput_ThrowsValidationException()
     {
         var act = () => User.From("thequickbrownfoxjumpedoverthewoodenlog@iwgplc.com", new UserTypeOptions { MinLength = 50 });
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.First().ErrorMessage.Should().Be("Could not create a Nox User type that is 49 characters long and shorter than the minimum specified length of 50.");
     }
 
@@ -76,7 +76,7 @@ public class UserTests
     public void User_Constructor_InvalidGuidType_ThrowsValidationException()
     {
         var act = () => User.From("thequickbrownfoxjumpedoverthewoodenlog@iwgplc.com", new UserTypeOptions { ValidGuidFormat = true, ValidEmailFormat = false, IsCaseSensitive = true });
-        act.Should().Throw<TypeValidationException>().And.Errors.First().ErrorMessage
+        act.Should().Throw<NoxTypeValidationException>().And.Errors.First().ErrorMessage
             .Should().Be("Could not create a Nox User type thequickbrownfoxjumpedoverthewoodenlog@iwgplc.com as it is not a valid Guid.");
     }
 
@@ -85,7 +85,7 @@ public class UserTests
     {
         var userGuid = Guid.NewGuid().ToString();
         var act = () => User.From(userGuid, new UserTypeOptions { ValidGuidFormat = false, ValidEmailFormat = true, IsCaseSensitive = true });
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.First().ErrorMessage
             .Should().Be($"Could not create a Nox User type {userGuid} as it is not a valid email address.");
     }
@@ -95,7 +95,7 @@ public class UserTests
     {
         var userId = "AyeDee";
         var act = () => User.From(userId);
-        act.Should().Throw<TypeValidationException>()
+        act.Should().Throw<NoxTypeValidationException>()
             .And.Errors.First().ErrorMessage
             .Should().Be($"Could not create a Nox User type {userId} as it is not a valid guid or email address.");
     }

--- a/tests/Nox.Types.Tests/Types/VatNumberTests/VatNumberTests.cs
+++ b/tests/Nox.Types.Tests/Types/VatNumberTests/VatNumberTests.cs
@@ -23,7 +23,7 @@ public class VatNumberTests
 
         var action = () => VatNumber.From(vatNumberValue, countryCode);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox VatNumber type with unsupported CountryCode 'UA'.") });
     }
 
@@ -35,7 +35,7 @@ public class VatNumberTests
 
         var action = () => VatNumber.From(vatNumberValue, countryCode);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox VatNumber type with unsupported value 'FR44403198682123'.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Volume/VolumeTests.cs
+++ b/tests/Nox.Types.Tests/Types/Volume/VolumeTests.cs
@@ -68,7 +68,7 @@ public class VolumeTests
     {
         var action = () => Volume.From(-28);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Volume type as negative value -28 is not allowed.") });
     }
 
@@ -77,7 +77,7 @@ public class VolumeTests
     {
         var action = () => Volume.From(double.NaN);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value NaN is not allowed.") });
     }
@@ -87,7 +87,7 @@ public class VolumeTests
     {
         var action = () => Volume.From(double.PositiveInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -97,7 +97,7 @@ public class VolumeTests
     {
         var action = () => Volume.From(double.NegativeInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[]
                 { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }
@@ -248,7 +248,7 @@ public class VolumeTests
             var action = () =>
                 Volume.From(7.5, new VolumeTypeOptions { MaxValue = 5, Unit = VolumeTypeUnit.CubicMeter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -267,7 +267,7 @@ public class VolumeTests
             var action = () =>
                 Volume.From(7.5, new VolumeTypeOptions { MinValue = 10, Unit = VolumeTypeUnit.CubicMeter });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",

--- a/tests/Nox.Types.Tests/Types/Weight/WeightTests.cs
+++ b/tests/Nox.Types.Tests/Types/Weight/WeightTests.cs
@@ -45,7 +45,7 @@ public class WeightTests
             var action = () =>
                 Weight.From(7.5, new WeightTypeOptions { MaxValue = 5, Units = WeightTypeUnit.Kilogram });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -64,7 +64,7 @@ public class WeightTests
             var action = () =>
                 Weight.From(7.5, new WeightTypeOptions { MinValue = 10, Units = WeightTypeUnit.Kilogram });
 
-            action.Should().Throw<TypeValidationException>()
+            action.Should().Throw<NoxTypeValidationException>()
                 .And.Errors.Should().BeEquivalentTo(new[]
                 {
                     new ValidationFailure("Value",
@@ -80,7 +80,7 @@ public class WeightTests
     {
         var action = () => Weight.From(-100);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox Weight type as negative weight value -100 is not allowed.") });
     }
 
@@ -89,7 +89,7 @@ public class WeightTests
     {
         var action = () => Weight.From(double.NaN);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox type as value NaN is not allowed.") });
     }
 
@@ -99,7 +99,7 @@ public class WeightTests
         var action = () => Weight.From(double.PositiveInfinity);
 
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }
 
@@ -108,7 +108,7 @@ public class WeightTests
     {
         var action = () => Weight.From(double.NegativeInfinity);
 
-        action.Should().Throw<TypeValidationException>()
+        action.Should().Throw<NoxTypeValidationException>()
             .And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", "Could not create a Nox type as value Infinity is not allowed.") });
     }
 

--- a/tests/Nox.Types.Tests/Types/Yaml/YamlTests.cs
+++ b/tests/Nox.Types.Tests/Types/Yaml/YamlTests.cs
@@ -43,7 +43,7 @@ public class YamlTests
         string yamlString = System.IO.File.ReadAllText( Path.Combine(FileRoot,InvalidFolder, fileName));
         
         // Arrange & Act
-        var exception = Assert.Throws<TypeValidationException>(() => Yaml.From(yamlString));
+        var exception = Assert.Throws<NoxTypeValidationException>(() => Yaml.From(yamlString));
 
         // Assert
         exception.Errors.Should().NotHaveCount(0);

--- a/tests/Nox.Types.Tests/Types/Year/YearTests.cs
+++ b/tests/Nox.Types.Tests/Types/Year/YearTests.cs
@@ -25,7 +25,7 @@ public class YearTests
         var action = () => Year.From(value);
 
         // Assert
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type as value {value} is less than the minimum specified value of 1900") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type as value {value} is less than the minimum specified value of 1900") });
     }
 
     [Theory]
@@ -39,7 +39,7 @@ public class YearTests
         var action = () => Year.From(value);
 
         // Assert
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value {value} is greater than the maximum specified value of 3000") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value {value} is greater than the maximum specified value of 3000") });
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class YearTests
         var action = () => Year.From(yearValue, new YearTypeOptions { AllowFutureOnly = true });
 
         // Assert 
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value 2020 is less than the current year") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value 2020 is less than the current year") });
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class YearTests
         var action = () => Year.From(yearValue, new YearTypeOptions { MaxValue = 10 });
 
         // Assert 
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value 1900 is greater than the maximum specified value of 10") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type a value 1900 is greater than the maximum specified value of 10") });
     }
 
     [Fact]
@@ -115,6 +115,6 @@ public class YearTests
         var action = () => Year.From(yearValue, new YearTypeOptions { MinValue = 50 });
 
         // Assert 
-        action.Should().Throw<TypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type as value 1 is less than the minimum specified value of 50") });
+        action.Should().Throw<NoxTypeValidationException>().And.Errors.Should().BeEquivalentTo(new[] { new ValidationFailure("Value", $"Could not create a Nox Year type as value 1 is less than the minimum specified value of 50") });
     }
 }


### PR DESCRIPTION
raise badrequestexception in generated endpoints to control the error output 
also update generated factories  to control the error output 

Examples of the output:
![image](https://github.com/NoxOrg/Nox.Generator/assets/8514193/05e32003-8f9c-497a-ac37-ae609c1aad82)
