### PR TITLE
Allow different signatures for Http verbs on dynamic Api middleware

### DIFF
--- a/schemas/integrationTarget.json
+++ b/schemas/integrationTarget.json
@@ -57,6 +57,65 @@
                   "type": "null"
                 }
               ]
+            },
+            "watermark": {    
+              "title": "Definition namespace for watermark columns on the integration target data.",
+              "description": "This section lists the column(s) on the target data used to determine whether a record is new or has been updated.",
+              "oneOf": [
+                {
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "properties": {
+                "sequentialKeyColumns": {    
+                  "title": "Sequential key column used for watermark purpose.",
+                  "description": "Specify one or more sequential key columns to be compared to source data to determine if a record exits in the target.",
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "items":   {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "dateColumns": {    
+                  "title": "Column(s) in datetime format used for watermark purpose.",
+                  "description": "List of datetime columns to be compared to source data to determine if data has changed.",
+                  "oneOf": [
+                    {
+                      "type": "array"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "items":   {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/src/Nox.Abstractions/Nox.Abstractions.csproj
+++ b/src/Nox.Abstractions/Nox.Abstractions.csproj
@@ -40,7 +40,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Nox.Solution\Nox.Solution.csproj" />
       <ProjectReference Include="..\Nox.Types\Nox.Types.csproj" />
     </ItemGroup>
         

--- a/src/Nox.ClientApi.Tests/.nox/docs/IntegrationEvents.md
+++ b/src/Nox.ClientApi.Tests/.nox/docs/IntegrationEvents.md
@@ -159,6 +159,7 @@ Member|Type|Description
 ------|----|-----------
 Id|System.Int64|Workplace unique identifier
 Name|System.String|Workplace Name
+ReferenceNumber|System.String|Workplace Code
 Description|System.String|Workplace Description
 Greeting|System.String|The Formula
 CountryId|System.Int64|The unique identifier

--- a/src/Nox.ClientApi.Tests/.nox/docs/README.md
+++ b/src/Nox.ClientApi.Tests/.nox/docs/README.md
@@ -325,6 +325,7 @@ Member|Type|Description|Info
 ---------|----|----------|-------
 Id|AutoNumber|Workplace unique identifier.|Required, Primary Key
 Name|Text|Workplace Name.|Required, MinLength: 4, MaxLength: 63
+ReferenceNumber|ReferenceNumber|Workplace Code.|StartsAt: 10, IncrementsBy: 5
 Description|Text|Workplace Description.|MinLength: 4, IsLocalized: true
 Greeting|Formula|The Formula.|
 CountryId|AutoNumber|The unique identifier.|Required, Foreign Key, StartsAt: 10, IncrementsBy: 5

--- a/src/Nox.ClientApi.Tests/.nox/docs/domainEvents/WorkplaceDomainEvents.md
+++ b/src/Nox.ClientApi.Tests/.nox/docs/domainEvents/WorkplaceDomainEvents.md
@@ -14,6 +14,7 @@ Member|Type|Description
 ------|----|-----------
 Id|AutoNumber|Workplace unique identifier
 Name|Text|Workplace Name
+ReferenceNumber|ReferenceNumber|Workplace Code
 Description|Text|Workplace Description
 Greeting|Formula|The Formula
 CountryId|AutoNumber|The unique identifier
@@ -30,6 +31,7 @@ Member|Type|Description
 ------|----|-----------
 Id|AutoNumber|Workplace unique identifier
 Name|Text|Workplace Name
+ReferenceNumber|ReferenceNumber|Workplace Code
 Description|Text|Workplace Description
 Greeting|Formula|The Formula
 CountryId|AutoNumber|The unique identifier
@@ -46,6 +48,7 @@ Member|Type|Description
 ------|----|-----------
 Id|AutoNumber|Workplace unique identifier
 Name|Text|Workplace Name
+ReferenceNumber|ReferenceNumber|Workplace Code
 Description|Text|Workplace Description
 Greeting|Formula|The Formula
 CountryId|AutoNumber|The unique identifier

--- a/src/Nox.Lib/Nox.Lib.csproj
+++ b/src/Nox.Lib/Nox.Lib.csproj
@@ -64,7 +64,6 @@
 		<ProjectReference Include="..\Nox.Monitoring.ElasticApm\Nox.Monitoring.ElasticApm.csproj" />
 		<ProjectReference Include="..\Nox.Secrets\Nox.Secrets.csproj" />
 		<ProjectReference Include="..\Nox.Solution\Nox.Solution.csproj" />
-		<ProjectReference Include="..\Nox.Yaml\Nox.Yaml.csproj" />
 		<ProjectReference Include="..\Nox.Abstractions\Nox.Abstractions.csproj" />
 		<ProjectReference Include="..\Nox.Generator\Nox.Generator.csproj" PrivateAssets="all" />
 		<ProjectReference Include="..\Nox.Types\Nox.Types.csproj" />

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/PartialUpdateForReferenceNumberCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/PartialUpdateForReferenceNumberCommand.g.cs
@@ -16,7 +16,7 @@ using ForReferenceNumberEntity = TestWebApp.Domain.ForReferenceNumber;
 
 namespace TestWebApp.Application.Commands;
 
-public record PartialUpdateForReferenceNumberCommand(System.String keyId, Dictionary<string, dynamic> UpdatedProperties, Nox.Types.CultureCode CultureCode, System.Guid? Etag) : IRequest <ForReferenceNumberKeyDto?>;
+public partial record PartialUpdateForReferenceNumberCommand(System.String keyId, Dictionary<string, dynamic> UpdatedProperties, Nox.Types.CultureCode CultureCode, System.Guid? Etag) : IRequest <ForReferenceNumberKeyDto?>;
 
 internal class PartialUpdateForReferenceNumberCommandHandler : PartialUpdateForReferenceNumberCommandHandlerBase
 {

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateForReferenceNumberCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateForReferenceNumberCommand.g.cs
@@ -17,7 +17,7 @@ using ForReferenceNumberEntity = TestWebApp.Domain.ForReferenceNumber;
 
 namespace TestWebApp.Application.Commands;
 
-public record UpdateForReferenceNumberCommand(System.String keyId, ForReferenceNumberUpdateDto EntityDto, Nox.Types.CultureCode CultureCode, System.Guid? Etag) : IRequest<ForReferenceNumberKeyDto?>;
+public partial record UpdateForReferenceNumberCommand(System.String keyId, ForReferenceNumberUpdateDto EntityDto, Nox.Types.CultureCode CultureCode, System.Guid? Etag) : IRequest<ForReferenceNumberKeyDto?>;
 
 internal partial class UpdateForReferenceNumberCommandHandler : UpdateForReferenceNumberCommandHandlerBase
 {

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ForReferenceNumbersController.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Presentation.Api.OData/ForReferenceNumbersController.g.cs
@@ -12,6 +12,7 @@ using MediatR;
 using System;
 using System.Net.Http.Headers;
 using Nox.Application;
+using Nox.Application.Dto;
 using Nox.Extensions;
 using TestWebApp.Application;
 using TestWebApp.Application.Dto;

--- a/tests/Nox.Integration.Tests/ProjectDependencies/ProjectsDependenciesTests.cs
+++ b/tests/Nox.Integration.Tests/ProjectDependencies/ProjectsDependenciesTests.cs
@@ -88,7 +88,7 @@ namespace Nox.Tests.ProjectDependencies
         public void Nox_Abstraction_References_Nox_Types_And_Solution_Only()
         {
             var projectDependencies =
-                _fixture.ProjectDependencyGraph.GetProjectsThatThisProjectDirectlyDependsOn(_fixture.NoxAbstractions.Id);
+                _fixture.ProjectDependencyGraph.GetProjectsThatThisProjectTransitivelyDependsOn(_fixture.NoxAbstractions.Id);
 
             projectDependencies.Should().HaveCount(3);
 

--- a/tests/Nox.Integration.Tests/ProjectDependencies/ProjectsDependenciesTests.cs
+++ b/tests/Nox.Integration.Tests/ProjectDependencies/ProjectsDependenciesTests.cs
@@ -90,10 +90,11 @@ namespace Nox.Tests.ProjectDependencies
             var projectDependencies =
                 _fixture.ProjectDependencyGraph.GetProjectsThatThisProjectDirectlyDependsOn(_fixture.NoxAbstractions.Id);
 
-            projectDependencies.Should().HaveCount(2);
+            projectDependencies.Should().HaveCount(3);
 
             projectDependencies.SingleOrDefault(d => d.Id == _fixture.NoxTypesProject.Id.Id).Should().NotBeNull();
-            projectDependencies.SingleOrDefault(d => d.Id == _fixture.NoxSolution.Id.Id).Should().NotBeNull();
+            projectDependencies.SingleOrDefault(d => d.Id == _fixture.NoxTypesAbstractionsProject.Id.Id).Should().NotBeNull();
+            projectDependencies.SingleOrDefault(d => d.Id == _fixture.NoxYamlProject.Id.Id).Should().NotBeNull();
         }
         #region Nox.Solution
         [Fact]


### PR DESCRIPTION
- Maintain separate api patterns per verb in middleware
- Allows unique match per verb for same endpoint  