### PR TITLE
feature 294 Remove Try Catch and remove AutoMapper Ref

### DIFF
--- a/samples/Cryptocash.Api/Cryptocash.Api.csproj
+++ b/samples/Cryptocash.Api/Cryptocash.Api.csproj
@@ -43,7 +43,6 @@
 	</ItemGroup>
 
    <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="12.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.14" />
         <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.14">

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashBookingDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashBookingDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCashStockOrderDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCashStockOrderDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCommissionDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCommissionDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCountryDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCountryDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCustomerDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCustomerDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashEmployeeDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashEmployeeDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Nox.Extensions;

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashLandLordDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashLandLordDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Nox.Types.Common;

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashMinimumCashStockDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashMinimumCashStockDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashPaymentDetailDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashPaymentDetailDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashPaymentProviderDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashPaymentProviderDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashTransactionDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashTransactionDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashVendingMachineDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashVendingMachineDataSeeder.cs
@@ -3,7 +3,6 @@ using Cryptocash.DataSeed.Seeders;
 using Cryptocash.Domain;
 using Cryptocash.Infrastructure.Persistence;
 using Cryptocash.Application.Dto;
-using AutoMapper;
 using MassTransit.Transports;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Nox.Types.Common;


### PR DESCRIPTION
PR to Remove Try Catch on DataSeeder and allow Errors to be raised - useful when importing Data

Also removed AutoMapper Ref in Cryptocash.Api project as no longer required