### PR TITLE
add language query parameter to swagger for all gets

### DIFF
--- a/src/Nox.Lib/Presentation/Api/OData/LanguageQueryParameterOperationFilter.cs
+++ b/src/Nox.Lib/Presentation/Api/OData/LanguageQueryParameterOperationFilter.cs
@@ -1,23 +1,14 @@
 using Microsoft.OpenApi.Models;
-using Nox.Solution;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Nox.Presentation.Api.OData;
 
 public class LanguageQueryParameterOperationFilter: IOperationFilter
 {
-    private readonly HashSet<string> _auditEntityPaths;
-
-    public LanguageQueryParameterOperationFilter(NoxSolution noxSolution)
-    {
-        _auditEntityPaths = 
-            noxSolution.Domain!.Entities.Where(e => e.IsLocalized)
-                .Select(e=> string.Concat(noxSolution.Presentation.ApiConfiguration.ApiRoutePrefix, "/", e.PluralName)).ToHashSet();
-    }
     
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        if (context.ApiDescription.HttpMethod == HttpMethod.Get.Method && _auditEntityPaths.Any(p => p.Contains(context.ApiDescription.RelativePath!)))
+        if (context.ApiDescription.HttpMethod == HttpMethod.Get.Method)
         {
             operation.Parameters.Add(new OpenApiParameter
             {


### PR DESCRIPTION
there are differet use cases that would require to parse the request path to understand if related end points support or not localization