### PR TITLE
fix langugage parameter style in OpenApi

### DIFF
--- a/src/Nox.Lib/Presentation/Api/Swagger/LanguageQueryParameterOperationFilter.cs
+++ b/src/Nox.Lib/Presentation/Api/Swagger/LanguageQueryParameterOperationFilter.cs
@@ -15,7 +15,6 @@ internal class LanguageQueryParameterOperationFilter : IOperationFilter
                 Name = QueryParams.Language,
                 Description = "language parameter",
                 In = ParameterLocation.Query,
-                Style = ParameterStyle.Simple,
                 Schema = new OpenApiSchema
                 {
                     Type = "string",


### PR DESCRIPTION
Simple style is not valid for Query Parameters

![image](https://github.com/NoxOrg/Nox/assets/8514193/39164617-a693-4b55-95ce-7429ee697ccf)
