### PR TITLE
NOX-849 - Update Put Entity behavior for OneOrMany Owned Entities

### DIFF
--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCountryDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCountryDataSeeder.cs
@@ -44,7 +44,7 @@ internal class CryptocashCountryDataSeeder : DataSeederBase<CountryDto, Country>
         {
             foreach (CountryTimeZoneDto currentCountryTimeZone in model.CountryTimeZones)
             {
-                rtnCountry.CreateRefToCountryTimeZones(
+                rtnCountry.CreateCountryTimeZones(
                     new()
                     {
                         TimeZoneCode = TimeZoneCode.From(currentCountryTimeZone.TimeZoneCode)
@@ -57,7 +57,7 @@ internal class CryptocashCountryDataSeeder : DataSeederBase<CountryDto, Country>
         {
             foreach (HolidayDto currentHoliday in model.Holidays)
             {
-                rtnCountry.CreateRefToHolidays(
+                rtnCountry.CreateHolidays(
                     new()
                     {
                         Name = Text.From(currentHoliday.Name),

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCurrencyDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashCurrencyDataSeeder.cs
@@ -40,7 +40,7 @@ internal class CryptocashCurrencyDataSeeder : DataSeederBase<CurrencyDto, Curren
         {
             foreach (BankNoteDto currentBankNote in model.BankNotes)
             {
-                rtnCurrency.CreateRefToBankNotes(
+                rtnCurrency.CreateBankNotes(
                     new()
                     {
                         CashNote = Text.From(currentBankNote.CashNote),
@@ -54,7 +54,7 @@ internal class CryptocashCurrencyDataSeeder : DataSeederBase<CurrencyDto, Curren
         {
             foreach (ExchangeRateDto currentExchangeRate in model.ExchangeRates)
             {
-                rtnCurrency.CreateRefToExchangeRates(
+                rtnCurrency.CreateExchangeRates(
                     new()
                     {
                         EffectiveRate = Number.From(currentExchangeRate.EffectiveRate),

--- a/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashEmployeeDataSeeder.cs
+++ b/samples/Cryptocash.Api/DataSeed/Seeders/CryptocashEmployeeDataSeeder.cs
@@ -35,7 +35,7 @@ internal class CryptocashEmployeeDataSeeder : DataSeederBase<EmployeeDto, Employ
         {
             foreach (EmployeePhoneNumberDto currentPhone in model.EmployeePhoneNumbers)
             {
-                rtnEmployee.CreateRefToEmployeePhoneNumbers(
+                rtnEmployee.CreateEmployeePhoneNumbers(
                     new()
                     {
                         PhoneNumber = PhoneNumber.From(currentPhone.PhoneNumber),

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateBankNotesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateBankNotesForCurrencyCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateBankNotesForCurrencyCommandHandlerBase : CommandBa
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToBankNotes(entity);
+		parentEntity.CreateBankNotes(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryTimeZonesForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryTimeZonesForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateCountryTimeZonesForCountryCommandHandlerBase : Com
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToCountryTimeZones(entity);
+		parentEntity.CreateCountryTimeZones(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateEmployeePhoneNumbersForEmployeeCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateEmployeePhoneNumbersForEmployeeCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateEmployeePhoneNumbersForEmployeeCommandHandlerBase 
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToEmployeePhoneNumbers(entity);
+		parentEntity.CreateEmployeePhoneNumbers(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateExchangeRatesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateExchangeRatesForCurrencyCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateExchangeRatesForCurrencyCommandHandlerBase : Comma
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToExchangeRates(entity);
+		parentEntity.CreateExchangeRates(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateHolidaysForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateHolidaysForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateHolidaysForCountryCommandHandlerBase : CommandBase
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToHolidays(entity);
+		parentEntity.CreateHolidays(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateBankNotesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateBankNotesForCurrencyCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateBankNotesForCurrencyCommandHandlerBase : CommandCol
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToBankNotes(entity);
+				parentEntity.CreateBankNotes(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateBankNotesForCurrencyCommandHandlerBase : CommandCol
 	private async Task<BankNoteEntity> CreateEntityAsync(BankNoteUpsertDto upsertDto, CurrencyEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToBankNotes(entity);
+		parent.CreateBankNotes(entity);
 		return entity;
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateBankNotesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateBankNotesForCurrencyCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateBankNotesForCurrencyCommandHandlerBase : CommandCol
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToBankNotes(entity);
 			}
 			else
 			{
 				var ownedId = Dto.BankNoteMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.BankNotes.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("BankNote",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToBankNotes(entity);
+				}
 			}
 
-			parentEntity.CreateRefToBankNotes(entity);
 			entities.Add(entity);
 		}
 

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToCountryTimeZones(entity);
+				parentEntity.CreateCountryTimeZones(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 	private async Task<CountryTimeZoneEntity> CreateEntityAsync(CountryTimeZoneUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToCountryTimeZones(entity);
+		parent.CreateCountryTimeZones(entity);
 		return entity;
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToCountryTimeZones(entity);
 			}
 			else
 			{
 				var ownedId = Dto.CountryTimeZoneMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.CountryTimeZones.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("CountryTimeZone",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToCountryTimeZones(entity);
+				}
 			}
 
-			parentEntity.CreateRefToCountryTimeZones(entity);
 			entities.Add(entity);
 		}
 

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmployeePhoneNumbersForEmployeeCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmployeePhoneNumbersForEmployeeCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateEmployeePhoneNumbersForEmployeeCommandHandlerBase :
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToEmployeePhoneNumbers(entity);
+				parentEntity.CreateEmployeePhoneNumbers(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateEmployeePhoneNumbersForEmployeeCommandHandlerBase :
 	private async Task<EmployeePhoneNumberEntity> CreateEntityAsync(EmployeePhoneNumberUpsertDto upsertDto, EmployeeEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToEmployeePhoneNumbers(entity);
+		parent.CreateEmployeePhoneNumbers(entity);
 		return entity;
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmployeePhoneNumbersForEmployeeCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmployeePhoneNumbersForEmployeeCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateEmployeePhoneNumbersForEmployeeCommandHandlerBase :
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToEmployeePhoneNumbers(entity);
 			}
 			else
 			{
 				var ownedId = Dto.EmployeePhoneNumberMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.EmployeePhoneNumbers.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("EmployeePhoneNumber",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToEmployeePhoneNumbers(entity);
+				}
 			}
 
-			parentEntity.CreateRefToEmployeePhoneNumbers(entity);
 			entities.Add(entity);
 		}
 

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateExchangeRatesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateExchangeRatesForCurrencyCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateExchangeRatesForCurrencyCommandHandlerBase : Comman
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToExchangeRates(entity);
+				parentEntity.CreateExchangeRates(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateExchangeRatesForCurrencyCommandHandlerBase : Comman
 	private async Task<ExchangeRateEntity> CreateEntityAsync(ExchangeRateUpsertDto upsertDto, CurrencyEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToExchangeRates(entity);
+		parent.CreateExchangeRates(entity);
 		return entity;
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateExchangeRatesForCurrencyCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateExchangeRatesForCurrencyCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateExchangeRatesForCurrencyCommandHandlerBase : Comman
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToExchangeRates(entity);
 			}
 			else
 			{
 				var ownedId = Dto.ExchangeRateMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.ExchangeRates.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("ExchangeRate",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToExchangeRates(entity);
+				}
 			}
 
-			parentEntity.CreateRefToExchangeRates(entity);
 			entities.Add(entity);
 		}
 

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToHolidays(entity);
+				parentEntity.CreateHolidays(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 	private async Task<HolidayEntity> CreateEntityAsync(HolidayUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToHolidays(entity);
+		parent.CreateHolidays(entity);
 		return entity;
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToHolidays(entity);
 			}
 			else
 			{
 				var ownedId = Dto.HolidayMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.Holidays.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("Holiday",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToHolidays(entity);
+				}
 			}
 
-			parentEntity.CreateRefToHolidays(entity);
 			entities.Add(entity);
 		}
 

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
@@ -128,27 +128,27 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         //createDto.CountryTimeZones?.ForEach(async dto =>
         //{
         //    var countryTimeZone = await CountryTimeZoneFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToCountryTimeZones(countryTimeZone);
+        //    entity.CreateCountryTimeZones(countryTimeZone);
         //});
         if(createDto.CountryTimeZones is not null)
         {
             foreach (var dto in createDto.CountryTimeZones)
             {
                 var countryTimeZone = CountryTimeZoneFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToCountryTimeZones(countryTimeZone);
+                entity.CreateCountryTimeZones(countryTimeZone);
             }
         }
         //createDto.Holidays?.ForEach(async dto =>
         //{
         //    var holiday = await HolidayFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToHolidays(holiday);
+        //    entity.CreateHolidays(holiday);
         //});
         if(createDto.Holidays is not null)
         {
             foreach (var dto in createDto.Holidays)
             {
                 var holiday = HolidayFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToHolidays(holiday);
+                entity.CreateHolidays(holiday);
             }
         }        
         return await Task.FromResult(entity);
@@ -406,7 +406,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         if(!updateDto.CountryTimeZones.Any())
         { 
             _repository.DeleteOwned(entity.CountryTimeZones);
-			entity.DeleteAllRefToCountryTimeZones();
+			entity.DeleteAllCountryTimeZones();
         }
 		else
 		{
@@ -433,7 +433,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 			}
             _repository.DeleteOwned<Cryptocash.Domain.CountryTimeZone>(
                 entity.CountryTimeZones.Where(x => !updatedCountryTimeZones.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToCountryTimeZones(updatedCountryTimeZones);
+			entity.UpdateCountryTimeZones(updatedCountryTimeZones);
 		}
 	}
 
@@ -445,7 +445,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         if(!updateDto.Holidays.Any())
         { 
             _repository.DeleteOwned(entity.Holidays);
-			entity.DeleteAllRefToHolidays();
+			entity.DeleteAllHolidays();
         }
 		else
 		{
@@ -472,7 +472,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 			}
             _repository.DeleteOwned<Cryptocash.Domain.Holiday>(
                 entity.Holidays.Where(x => !updatedHolidays.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToHolidays(updatedHolidays);
+			entity.UpdateHolidays(updatedHolidays);
 		}
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CurrencyFactory.g.cs
@@ -126,27 +126,27 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
         //createDto.BankNotes?.ForEach(async dto =>
         //{
         //    var bankNote = await BankNoteFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToBankNotes(bankNote);
+        //    entity.CreateBankNotes(bankNote);
         //});
         if(createDto.BankNotes is not null)
         {
             foreach (var dto in createDto.BankNotes)
             {
                 var bankNote = BankNoteFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToBankNotes(bankNote);
+                entity.CreateBankNotes(bankNote);
             }
         }
         //createDto.ExchangeRates?.ForEach(async dto =>
         //{
         //    var exchangeRate = await ExchangeRateFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToExchangeRates(exchangeRate);
+        //    entity.CreateExchangeRates(exchangeRate);
         //});
         if(createDto.ExchangeRates is not null)
         {
             foreach (var dto in createDto.ExchangeRates)
             {
                 var exchangeRate = ExchangeRateFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToExchangeRates(exchangeRate);
+                entity.CreateExchangeRates(exchangeRate);
             }
         }        
         return await Task.FromResult(entity);
@@ -315,7 +315,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
         if(!updateDto.BankNotes.Any())
         { 
             _repository.DeleteOwned(entity.BankNotes);
-			entity.DeleteAllRefToBankNotes();
+			entity.DeleteAllBankNotes();
         }
 		else
 		{
@@ -342,7 +342,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
 			}
             _repository.DeleteOwned<Cryptocash.Domain.BankNote>(
                 entity.BankNotes.Where(x => !updatedBankNotes.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToBankNotes(updatedBankNotes);
+			entity.UpdateBankNotes(updatedBankNotes);
 		}
 	}
 
@@ -354,7 +354,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
         if(!updateDto.ExchangeRates.Any())
         { 
             _repository.DeleteOwned(entity.ExchangeRates);
-			entity.DeleteAllRefToExchangeRates();
+			entity.DeleteAllExchangeRates();
         }
 		else
 		{
@@ -381,7 +381,7 @@ internal abstract class CurrencyFactoryBase : IEntityFactory<CurrencyEntity, Cur
 			}
             _repository.DeleteOwned<Cryptocash.Domain.ExchangeRate>(
                 entity.ExchangeRates.Where(x => !updatedExchangeRates.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToExchangeRates(updatedExchangeRates);
+			entity.UpdateExchangeRates(updatedExchangeRates);
 		}
 	}
 }

--- a/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EmployeeFactory.g.cs
+++ b/samples/Cryptocash.Application/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/EmployeeFactory.g.cs
@@ -108,14 +108,14 @@ internal abstract class EmployeeFactoryBase : IEntityFactory<EmployeeEntity, Emp
         //createDto.EmployeePhoneNumbers?.ForEach(async dto =>
         //{
         //    var employeePhoneNumber = await EmployeePhoneNumberFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToEmployeePhoneNumbers(employeePhoneNumber);
+        //    entity.CreateEmployeePhoneNumbers(employeePhoneNumber);
         //});
         if(createDto.EmployeePhoneNumbers is not null)
         {
             foreach (var dto in createDto.EmployeePhoneNumbers)
             {
                 var employeePhoneNumber = EmployeePhoneNumberFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToEmployeePhoneNumbers(employeePhoneNumber);
+                entity.CreateEmployeePhoneNumbers(employeePhoneNumber);
             }
         }        
         return await Task.FromResult(entity);
@@ -212,7 +212,7 @@ internal abstract class EmployeeFactoryBase : IEntityFactory<EmployeeEntity, Emp
         if(!updateDto.EmployeePhoneNumbers.Any())
         { 
             _repository.DeleteOwned(entity.EmployeePhoneNumbers);
-			entity.DeleteAllRefToEmployeePhoneNumbers();
+			entity.DeleteAllEmployeePhoneNumbers();
         }
 		else
 		{
@@ -239,7 +239,7 @@ internal abstract class EmployeeFactoryBase : IEntityFactory<EmployeeEntity, Emp
 			}
             _repository.DeleteOwned<Cryptocash.Domain.EmployeePhoneNumber>(
                 entity.EmployeePhoneNumbers.Where(x => !updatedEmployeePhoneNumbers.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToEmployeePhoneNumbers(updatedEmployeePhoneNumbers);
+			entity.UpdateEmployeePhoneNumbers(updatedEmployeePhoneNumbers);
 		}
 	}
 }

--- a/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
+++ b/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
@@ -317,9 +317,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void DeleteAllRefToCountryTimeZones()
     {
-        if(CountryTimeZones.HasExactlyOneItem())
-            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-        CountryTimeZones.Clear();
+        throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }﻿
 
     /// <summary>

--- a/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
+++ b/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
@@ -286,7 +286,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new CountryTimeZone entity.
     /// </summary>
-    public virtual void CreateRefToCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
+    public virtual void CreateCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
     {
         CountryTimeZones.Add(relatedCountryTimeZone);
     }
@@ -294,7 +294,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned CountryTimeZone entities.
     /// </summary>
-    public virtual void UpdateRefToCountryTimeZones(List<CountryTimeZone> relatedCountryTimeZone)
+    public virtual void UpdateCountryTimeZones(List<CountryTimeZone> relatedCountryTimeZone)
     {
         if(!relatedCountryTimeZone.HasAtLeastOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be updated.");
@@ -305,7 +305,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned CountryTimeZone entity.
     /// </summary>
-    public virtual void DeleteRefToCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
+    public virtual void DeleteCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
     {
         if(CountryTimeZones.HasExactlyOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be deleted.");
@@ -315,7 +315,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned CountryTimeZone entities.
     /// </summary>
-    public virtual void DeleteAllRefToCountryTimeZones()
+    public virtual void DeleteAllCountryTimeZones()
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }﻿
@@ -328,7 +328,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new Holiday entity.
     /// </summary>
-    public virtual void CreateRefToHolidays(Holiday relatedHoliday)
+    public virtual void CreateHolidays(Holiday relatedHoliday)
     {
         Holidays.Add(relatedHoliday);
     }
@@ -336,7 +336,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned Holiday entities.
     /// </summary>
-    public virtual void UpdateRefToHolidays(List<Holiday> relatedHoliday)
+    public virtual void UpdateHolidays(List<Holiday> relatedHoliday)
     {
         Holidays.Clear();
         Holidays.AddRange(relatedHoliday);
@@ -345,7 +345,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned Holiday entity.
     /// </summary>
-    public virtual void DeleteRefToHolidays(Holiday relatedHoliday)
+    public virtual void DeleteHolidays(Holiday relatedHoliday)
     {
         Holidays.Remove(relatedHoliday);
     }
@@ -353,7 +353,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned Holiday entities.
     /// </summary>
-    public virtual void DeleteAllRefToHolidays()
+    public virtual void DeleteAllHolidays()
     {
         Holidays.Clear();
     }

--- a/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Currency.g.cs
+++ b/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Currency.g.cs
@@ -229,7 +229,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new BankNote entity.
     /// </summary>
-    public virtual void CreateRefToBankNotes(BankNote relatedBankNote)
+    public virtual void CreateBankNotes(BankNote relatedBankNote)
     {
         BankNotes.Add(relatedBankNote);
     }
@@ -237,7 +237,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned BankNote entities.
     /// </summary>
-    public virtual void UpdateRefToBankNotes(List<BankNote> relatedBankNote)
+    public virtual void UpdateBankNotes(List<BankNote> relatedBankNote)
     {
         BankNotes.Clear();
         BankNotes.AddRange(relatedBankNote);
@@ -246,7 +246,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned BankNote entity.
     /// </summary>
-    public virtual void DeleteRefToBankNotes(BankNote relatedBankNote)
+    public virtual void DeleteBankNotes(BankNote relatedBankNote)
     {
         BankNotes.Remove(relatedBankNote);
     }
@@ -254,7 +254,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned BankNote entities.
     /// </summary>
-    public virtual void DeleteAllRefToBankNotes()
+    public virtual void DeleteAllBankNotes()
     {
         BankNotes.Clear();
     }﻿
@@ -267,7 +267,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new ExchangeRate entity.
     /// </summary>
-    public virtual void CreateRefToExchangeRates(ExchangeRate relatedExchangeRate)
+    public virtual void CreateExchangeRates(ExchangeRate relatedExchangeRate)
     {
         ExchangeRates.Add(relatedExchangeRate);
     }
@@ -275,7 +275,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned ExchangeRate entities.
     /// </summary>
-    public virtual void UpdateRefToExchangeRates(List<ExchangeRate> relatedExchangeRate)
+    public virtual void UpdateExchangeRates(List<ExchangeRate> relatedExchangeRate)
     {
         if(!relatedExchangeRate.HasAtLeastOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be updated.");
@@ -286,7 +286,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned ExchangeRate entity.
     /// </summary>
-    public virtual void DeleteRefToExchangeRates(ExchangeRate relatedExchangeRate)
+    public virtual void DeleteExchangeRates(ExchangeRate relatedExchangeRate)
     {
         if(ExchangeRates.HasExactlyOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be deleted.");
@@ -296,7 +296,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned ExchangeRate entities.
     /// </summary>
-    public virtual void DeleteAllRefToExchangeRates()
+    public virtual void DeleteAllExchangeRates()
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }

--- a/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Currency.g.cs
+++ b/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Currency.g.cs
@@ -298,9 +298,7 @@ public abstract partial class CurrencyBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void DeleteAllRefToExchangeRates()
     {
-        if(ExchangeRates.HasExactlyOneItem())
-            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-        ExchangeRates.Clear();
+        throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }
 
     

--- a/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Employee.g.cs
+++ b/samples/Cryptocash.Domain/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Employee.g.cs
@@ -163,7 +163,7 @@ public abstract partial class EmployeeBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new EmployeePhoneNumber entity.
     /// </summary>
-    public virtual void CreateRefToEmployeePhoneNumbers(EmployeePhoneNumber relatedEmployeePhoneNumber)
+    public virtual void CreateEmployeePhoneNumbers(EmployeePhoneNumber relatedEmployeePhoneNumber)
     {
         EmployeePhoneNumbers.Add(relatedEmployeePhoneNumber);
     }
@@ -171,7 +171,7 @@ public abstract partial class EmployeeBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned EmployeePhoneNumber entities.
     /// </summary>
-    public virtual void UpdateRefToEmployeePhoneNumbers(List<EmployeePhoneNumber> relatedEmployeePhoneNumber)
+    public virtual void UpdateEmployeePhoneNumbers(List<EmployeePhoneNumber> relatedEmployeePhoneNumber)
     {
         EmployeePhoneNumbers.Clear();
         EmployeePhoneNumbers.AddRange(relatedEmployeePhoneNumber);
@@ -180,7 +180,7 @@ public abstract partial class EmployeeBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned EmployeePhoneNumber entity.
     /// </summary>
-    public virtual void DeleteRefToEmployeePhoneNumbers(EmployeePhoneNumber relatedEmployeePhoneNumber)
+    public virtual void DeleteEmployeePhoneNumbers(EmployeePhoneNumber relatedEmployeePhoneNumber)
     {
         EmployeePhoneNumbers.Remove(relatedEmployeePhoneNumber);
     }
@@ -188,7 +188,7 @@ public abstract partial class EmployeeBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned EmployeePhoneNumber entities.
     /// </summary>
-    public virtual void DeleteAllRefToEmployeePhoneNumbers()
+    public virtual void DeleteAllEmployeePhoneNumbers()
     {
         EmployeePhoneNumbers.Clear();
     }

--- a/src/Nox.Core/Exceptions/RelationshipDeletionException.cs
+++ b/src/Nox.Core/Exceptions/RelationshipDeletionException.cs
@@ -1,7 +1,9 @@
 using System.Net;
+using System.Runtime.Serialization;
 
 namespace Nox.Exceptions;
 
+[Serializable]
 public class RelationshipDeletionException : Exception, IApplicationException
 {
     public RelationshipDeletionException(string message)
@@ -14,9 +16,14 @@ public class RelationshipDeletionException : Exception, IApplicationException
     {
     }
 
+    protected RelationshipDeletionException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+
     public HttpStatusCode? StatusCode => HttpStatusCode.BadRequest;
 
     public string ErrorCode => "can_not_delete_relationship";
 
-    public object? ErrorDetails => throw new NotImplementedException();
+    public object? ErrorDetails { get; private set; }
 }

--- a/src/Nox.Generator/Application/Commands/CreateOwnedCommand.template.cs
+++ b/src/Nox.Generator/Application/Commands/CreateOwnedCommand.template.cs
@@ -69,7 +69,7 @@ internal abstract class Create{{relationshipName}}For{{parent.Name}}CommandHandl
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefTo{{relationshipName}}(entity);
+		parentEntity.Create{{relationshipName}}(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/src/Nox.Generator/Application/Commands/DeleteOwnedCommand.template.cs
+++ b/src/Nox.Generator/Application/Commands/DeleteOwnedCommand.template.cs
@@ -71,7 +71,7 @@ internal partial class Delete{{relationshipName}}For{{parent.Name}}CommandHandle
 			throw new EntityNotFoundException("{{parent.Name}}.{{relationshipName}}",  String.Empty);
 		}
 
-		parentEntity.DeleteRefTo{{relationshipName}}(entity);
+		parentEntity.Delete{{relationshipName}}(entity);
 		
 		{{ else }}		
 		{{- for key in entity.Keys }}

--- a/src/Nox.Generator/Application/Commands/UpdateOwnedManyCommand.template.cs
+++ b/src/Nox.Generator/Application/Commands/UpdateOwnedManyCommand.template.cs
@@ -82,7 +82,7 @@ internal partial class {{className}}HandlerBase : CommandCollectionBase<{{classN
 			if(entityDto.{{key.Name}} is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefTo{{relationshipName}}(entity);
+				parentEntity.Create{{relationshipName}}(entity);
 			}
 			else
 			{
@@ -94,7 +94,7 @@ internal partial class {{className}}HandlerBase : CommandCollectionBase<{{classN
 					throw new EntityNotFoundException("{{entity.Name}}",  $"{{keysToString entity.Keys 'owned'}}");
 					{{- else }}
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-					parentEntity.CreateRefTo{{relationshipName}}(entity);
+					parentEntity.Create{{relationshipName}}(entity);
 					{{- end }}
 				}
 				else
@@ -117,7 +117,7 @@ internal partial class {{className}}HandlerBase : CommandCollectionBase<{{classN
 	private async Task<{{entity.Name}}Entity> CreateEntityAsync({{entity.Name}}UpsertDto upsertDto, {{parent.Name}}Entity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefTo{{relationshipName}}(entity);
+		parent.Create{{relationshipName}}(entity);
 		return entity;
 	}
 }

--- a/src/Nox.Generator/Application/Commands/UpdateOwnedSingleCommand.template.cs
+++ b/src/Nox.Generator/Application/Commands/UpdateOwnedSingleCommand.template.cs
@@ -95,7 +95,7 @@ internal partial class {{className}}HandlerBase : CommandBase<{{className}}, {{e
 	private async Task<{{entity.Name}}Entity> CreateEntityAsync({{entity.Name}}UpsertDto upsertDto, {{parent.Name}}Entity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefTo{{relationshipName}}(entity);
+		parent.Create{{relationshipName}}(entity);
 		return entity;
 	}
 	{{- end}}

--- a/src/Nox.Generator/Application/Factories/EntityFactory.template.cs
+++ b/src/Nox.Generator/Application/Factories/EntityFactory.template.cs
@@ -195,21 +195,21 @@ internal abstract class {{className}}Base : IEntityFactory<{{entity.Name}}Entity
         //createDto.{{relationshipName}}?.ForEach(async dto =>
         //{
         //    var {{ToLowerFirstChar relationship.Entity}} = await {{relationship.Entity}}Factory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefTo{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
+        //    entity.Create{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
         //});
         if(createDto.{{relationshipName}} is not null)
         {
             foreach (var dto in createDto.{{relationshipName}})
             {
                 var {{ToLowerFirstChar relationship.Entity}} = {{relationship.Entity}}Factory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefTo{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
+                entity.Create{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
             }
         }
             {{- else}}
         if (createDto.{{relationshipName}} is not null)
         {
             var {{ToLowerFirstChar relationship.Entity}} = await {{relationship.Entity}}Factory.CreateEntityAsync(createDto.{{relationshipName}}, cultureCode);
-            entity.CreateRefTo{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
+            entity.Create{{relationshipName}}({{ToLowerFirstChar relationship.Entity}});
         }
             {{-end}}
         {{- end }}        
@@ -320,14 +320,14 @@ internal abstract class {{className}}Base : IEntityFactory<{{entity.Name}}Entity
         {
             if(entity.{{navigationName}} is not null) 
                 _repository.DeleteOwned(entity.{{navigationName}});
-            entity.DeleteAllRefTo{{navigationName}}();
+            entity.DeleteAll{{navigationName}}();
         }
 		else
 		{
             if(entity.{{navigationName}} is not null)
                 await {{ownedRelationship.Entity}}Factory.UpdateEntityAsync(entity.{{navigationName}}, updateDto.{{navigationName}}, cultureCode);
             else
-			    entity.CreateRefTo{{navigationName}}(await {{ownedRelationship.Entity}}Factory.CreateEntityAsync(updateDto.{{navigationName}}, cultureCode));
+			    entity.Create{{navigationName}}(await {{ownedRelationship.Entity}}Factory.CreateEntityAsync(updateDto.{{navigationName}}, cultureCode));
         }
         {{- else }}
         if(updateDto.{{navigationName}} is null)
@@ -336,7 +336,7 @@ internal abstract class {{className}}Base : IEntityFactory<{{entity.Name}}Entity
         if(!updateDto.{{navigationName}}.Any())
         { 
             _repository.DeleteOwned(entity.{{navigationName}});
-			entity.DeleteAllRefTo{{navigationName}}();
+			entity.DeleteAll{{navigationName}}();
         }
 		else
 		{
@@ -367,7 +367,7 @@ internal abstract class {{className}}Base : IEntityFactory<{{entity.Name}}Entity
 			}
             _repository.DeleteOwned<{{codeGenConventions.DomainNameSpace}}.{{ownedRelationship.Entity}}>(
                 entity.{{navigationName}}.Where(x => !updated{{navigationName}}.Exists(upd => upd.{{key.Name}} == x.{{key.Name}})).ToList());
-			entity.UpdateRefTo{{navigationName}}(updated{{navigationName}});
+			entity.Update{{navigationName}}(updated{{navigationName}});
 		}
 		{{- end }}
 	}

--- a/src/Nox.Generator/Domain/Entity.template.cs
+++ b/src/Nox.Generator/Domain/Entity.template.cs
@@ -357,22 +357,14 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// </summary>
     public virtual void DeleteAllRefTo{{navigationName}}()
     {
-        {{- if relationship.WithSingleEntity }}
-
-			{{- if relationship.Relationship == "ExactlyOne" }}
+        {{- if relationship.Relationship == "ExactlyOne" || relationship.Relationship == "OneOrMany" }}
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-			{{- else }}
+
+        {{- else if relationship.Relationship == "ZeroOrOne" }}
         {{navigationName}} = null;
-			{{- end }}
 
-        {{- else}}
-
-			{{- if relationship.Relationship == "OneOrMany" }}
-        if({{navigationName}}.HasExactlyOneItem())
-            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-			{{- end }}
+        {{- else if relationship.Relationship == "ZeroOrMany" }}
         {{navigationName}}.Clear();
-
         {{- end }}
     }
 {{-end}}

--- a/src/Nox.Generator/Domain/Entity.template.cs
+++ b/src/Nox.Generator/Domain/Entity.template.cs
@@ -355,7 +355,7 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// <summary>
     /// Deletes all owned {{relationship.Entity}} entities.
     /// </summary>
-    public virtual void Delete{{navigationName}}()
+    public virtual void DeleteAll{{navigationName}}()
     {
         {{- if relationship.Relationship == "ExactlyOne" || relationship.Relationship == "OneOrMany" }}
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");

--- a/src/Nox.Generator/Domain/Entity.template.cs
+++ b/src/Nox.Generator/Domain/Entity.template.cs
@@ -303,7 +303,7 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// <summary>
     /// Creates a new {{relationship.Entity}} entity.
     /// </summary>
-    public virtual void CreateRefTo{{navigationName}}({{relationship.Entity}} related{{relationship.Entity}})
+    public virtual void Create{{navigationName}}({{relationship.Entity}} related{{relationship.Entity}})
     {
         {{- if relationship.WithSingleEntity }}
         {{navigationName}} = related{{relationship.Entity}};
@@ -317,7 +317,7 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// <summary>
     /// Updates all owned {{relationship.Entity}} entities.
     /// </summary>
-    public virtual void UpdateRefTo{{navigationName}}(List<{{relationship.Entity}}> related{{relationship.Entity}})
+    public virtual void Update{{navigationName}}(List<{{relationship.Entity}}> related{{relationship.Entity}})
     {
         {{- if relationship.Relationship == "OneOrMany" }}
         if(!related{{relationship.Entity}}.HasAtLeastOneItem())
@@ -331,7 +331,7 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// <summary>
     /// Deletes owned {{relationship.Entity}} entity.
     /// </summary>
-    public virtual void DeleteRefTo{{navigationName}}({{relationship.Entity}} related{{relationship.Entity}})
+    public virtual void Delete{{navigationName}}({{relationship.Entity}} related{{relationship.Entity}})
     {
         {{- if relationship.WithSingleEntity }}
 
@@ -355,7 +355,7 @@ public abstract partial class {{className}}Base{{ if !entity.IsOwnedEntity }} : 
     /// <summary>
     /// Deletes all owned {{relationship.Entity}} entities.
     /// </summary>
-    public virtual void DeleteAllRefTo{{navigationName}}()
+    public virtual void Delete{{navigationName}}()
     {
         {{- if relationship.Relationship == "ExactlyOne" || relationship.Relationship == "OneOrMany" }}
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");

--- a/tests/Nox.ClientApi.Tests/.nox/design/Entitities/country.entity.nox.yaml
+++ b/tests/Nox.ClientApi.Tests/.nox/design/Entitities/country.entity.nox.yaml
@@ -125,7 +125,7 @@ ownedRelationships:
 
   - name: CountryTimeZone
     description: uses
-    relationship: zeroOrMany
+    relationship: oneOrMany
     entity: CountryTimeZone
 
   - name: CountryOwnedHolidays

--- a/tests/Nox.ClientApi.Tests/.nox/docs/README.md
+++ b/tests/Nox.ClientApi.Tests/.nox/docs/README.md
@@ -14,7 +14,7 @@ erDiagram
     }
     Country||--o{CountryLocalName : "is also know as"
     Country||--o|CountryBarCode : "is also coded as"
-    Country||--o{CountryTimeZone : "uses"
+    Country||--|{CountryTimeZone : "uses"
     Country||--o{Holiday : "owned"
     CountryLocalName {
     }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryBarCodeForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryBarCodeForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateCountryBarCodeForCountryCommandHandlerBase : Comma
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToCountryBarCode(entity);
+		parentEntity.CreateCountryBarCode(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryLocalNamesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryLocalNamesForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateCountryLocalNamesForCountryCommandHandlerBase : Co
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToCountryLocalNames(entity);
+		parentEntity.CreateCountryLocalNames(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryTimeZonesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateCountryTimeZonesForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateCountryTimeZonesForCountryCommandHandlerBase : Com
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToCountryTimeZones(entity);
+		parentEntity.CreateCountryTimeZones(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateEmailAddressForStoreCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateEmailAddressForStoreCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateEmailAddressForStoreCommandHandlerBase : CommandBa
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToEmailAddress(entity);
+		parentEntity.CreateEmailAddress(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateHolidaysForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateHolidaysForCountryCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateHolidaysForCountryCommandHandlerBase : CommandBase
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToHolidays(entity);
+		parentEntity.CreateHolidays(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateTenantBrandsForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateTenantBrandsForTenantCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateTenantBrandsForTenantCommandHandlerBase : CommandB
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToTenantBrands(entity);
+		parentEntity.CreateTenantBrands(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateTenantContactForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateTenantContactForTenantCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateTenantContactForTenantCommandHandlerBase : Command
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToTenantContact(entity);
+		parentEntity.CreateTenantContact(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateUserContactSelectionForPersonCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateUserContactSelectionForPersonCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateUserContactSelectionForPersonCommandHandlerBase : 
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToUserContactSelection(entity);
+		parentEntity.CreateUserContactSelection(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteCountryBarCodeForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteCountryBarCodeForCountryCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteCountryBarCodeForCountryCommandHandlerBase : Comman
 			throw new EntityNotFoundException("Country.CountryBarCode",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToCountryBarCode(entity);
+		parentEntity.DeleteCountryBarCode(entity);
 		
 		
 		

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteEmailAddressForStoreCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteEmailAddressForStoreCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteEmailAddressForStoreCommandHandlerBase : CommandBas
 			throw new EntityNotFoundException("Store.EmailAddress",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToEmailAddress(entity);
+		parentEntity.DeleteEmailAddress(entity);
 		
 		
 		

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteTenantContactForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteTenantContactForTenantCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteTenantContactForTenantCommandHandlerBase : CommandB
 			throw new EntityNotFoundException("Tenant.TenantContact",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToTenantContact(entity);
+		parentEntity.DeleteTenantContact(entity);
 		
 		
 		

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteUserContactSelectionForPersonCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteUserContactSelectionForPersonCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteUserContactSelectionForPersonCommandHandlerBase : C
 			throw new EntityNotFoundException("Person.UserContactSelection",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToUserContactSelection(entity);
+		parentEntity.DeleteUserContactSelection(entity);
 		
 		
 		

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryBarCodeForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryBarCodeForCountryCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateCountryBarCodeForCountryCommandHandlerBase : Comman
 	private async Task<CountryBarCodeEntity> CreateEntityAsync(CountryBarCodeUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToCountryBarCode(entity);
+		parent.CreateCountryBarCode(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryLocalNamesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryLocalNamesForCountryCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateCountryLocalNamesForCountryCommandHandlerBase : Com
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToCountryLocalNames(entity);
+				parentEntity.CreateCountryLocalNames(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateCountryLocalNamesForCountryCommandHandlerBase : Com
 	private async Task<CountryLocalNameEntity> CreateEntityAsync(CountryLocalNameUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToCountryLocalNames(entity);
+		parent.CreateCountryLocalNames(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryLocalNamesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryLocalNamesForCountryCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateCountryLocalNamesForCountryCommandHandlerBase : Com
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToCountryLocalNames(entity);
 			}
 			else
 			{
 				var ownedId = Dto.CountryLocalNameMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.CountryLocalNames.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("CountryLocalName",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToCountryLocalNames(entity);
+				}
 			}
 
-			parentEntity.CreateRefToCountryLocalNames(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
@@ -67,20 +67,23 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToCountryTimeZones(entity);
 			}
 			else
 			{
 				var ownedId = Dto.CountryTimeZoneMetadata.CreateId(entityDto.Id.NonNullValue<System.String>());
 				entity = parentEntity.CountryTimeZones.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+					parentEntity.CreateRefToCountryTimeZones(entity);
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToCountryTimeZones(entity);
+				}
 			}
 
-			parentEntity.CreateRefToCountryTimeZones(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateCountryTimeZonesForCountryCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToCountryTimeZones(entity);
+				parentEntity.CreateCountryTimeZones(entity);
 			}
 			else
 			{
@@ -76,7 +76,7 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 				if (entity is null)
 				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-					parentEntity.CreateRefToCountryTimeZones(entity);
+					parentEntity.CreateCountryTimeZones(entity);
 				}
 				else
 				{
@@ -98,7 +98,7 @@ internal partial class UpdateCountryTimeZonesForCountryCommandHandlerBase : Comm
 	private async Task<CountryTimeZoneEntity> CreateEntityAsync(CountryTimeZoneUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToCountryTimeZones(entity);
+		parent.CreateCountryTimeZones(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmailAddresForStoreCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateEmailAddresForStoreCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateEmailAddresForStoreCommandHandlerBase : CommandBase
 	private async Task<EmailAddressEntity> CreateEntityAsync(EmailAddressUpsertDto upsertDto, StoreEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToEmailAddress(entity);
+		parent.CreateEmailAddress(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToHolidays(entity);
+				parentEntity.CreateHolidays(entity);
 			}
 			else
 			{
@@ -76,7 +76,7 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 				if (entity is null)
 				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-					parentEntity.CreateRefToHolidays(entity);
+					parentEntity.CreateHolidays(entity);
 				}
 				else
 				{
@@ -98,7 +98,7 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 	private async Task<HolidayEntity> CreateEntityAsync(HolidayUpsertDto upsertDto, CountryEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToHolidays(entity);
+		parent.CreateHolidays(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateHolidaysForCountryCommand.g.cs
@@ -67,20 +67,23 @@ internal partial class UpdateHolidaysForCountryCommandHandlerBase : CommandColle
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToHolidays(entity);
 			}
 			else
 			{
 				var ownedId = Dto.HolidayMetadata.CreateId(entityDto.Id.NonNullValue<System.Guid>());
 				entity = parentEntity.Holidays.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+					parentEntity.CreateRefToHolidays(entity);
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToHolidays(entity);
+				}
 			}
 
-			parentEntity.CreateRefToHolidays(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantBrandsForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantBrandsForTenantCommand.g.cs
@@ -67,20 +67,22 @@ internal partial class UpdateTenantBrandsForTenantCommandHandlerBase : CommandCo
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToTenantBrands(entity);
 			}
 			else
 			{
 				var ownedId = Dto.TenantBrandMetadata.CreateId(entityDto.Id.NonNullValue<System.Int64>());
 				entity = parentEntity.TenantBrands.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					throw new EntityNotFoundException("TenantBrand",  $"ownedId");
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToTenantBrands(entity);
+				}
 			}
 
-			parentEntity.CreateRefToTenantBrands(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantBrandsForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantBrandsForTenantCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateTenantBrandsForTenantCommandHandlerBase : CommandCo
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToTenantBrands(entity);
+				parentEntity.CreateTenantBrands(entity);
 			}
 			else
 			{
@@ -97,7 +97,7 @@ internal partial class UpdateTenantBrandsForTenantCommandHandlerBase : CommandCo
 	private async Task<TenantBrandEntity> CreateEntityAsync(TenantBrandUpsertDto upsertDto, TenantEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToTenantBrands(entity);
+		parent.CreateTenantBrands(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantContactForTenantCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateTenantContactForTenantCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateTenantContactForTenantCommandHandlerBase : CommandB
 	private async Task<TenantContactEntity> CreateEntityAsync(TenantContactUpsertDto upsertDto, TenantEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToTenantContact(entity);
+		parent.CreateTenantContact(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateUserContactSelectionForPersonCommand.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateUserContactSelectionForPersonCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateUserContactSelectionForPersonCommandHandlerBase : C
 	private async Task<UserContactSelectionEntity> CreateEntityAsync(UserContactSelectionUpsertDto upsertDto, PersonEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToUserContactSelection(entity);
+		parent.CreateUserContactSelection(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryCreateDto.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryCreateDto.g.cs
@@ -105,7 +105,7 @@ public abstract class CountryCreateDtoBase
     public virtual CountryBarCodeUpsertDto? CountryBarCode { get; set; } = null!;
 
     /// <summary>
-    /// Country uses ZeroOrMany CountryTimeZones
+    /// Country uses OneOrMany CountryTimeZones
     /// </summary>
     public virtual List<CountryTimeZoneUpsertDto> CountryTimeZones { get; set; } = new();
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryDto.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryDto.g.cs
@@ -162,7 +162,7 @@ public abstract class CountryDtoBase : EntityDtoBase
     public virtual CountryBarCodeDto? CountryBarCode { get; set; } = null!;
 
     /// <summary>
-    /// Country uses ZeroOrMany CountryTimeZones
+    /// Country uses OneOrMany CountryTimeZones
     /// </summary>
     public virtual List<CountryTimeZoneDto> CountryTimeZones { get; set; } = new();
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryUpdateDto.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Dto/CountryUpdateDto.g.cs
@@ -84,7 +84,7 @@ public partial class CountryUpdateDtoBase: EntityDtoBase
     /// </summary>
     public virtual CountryBarCodeUpsertDto? CountryBarCode { get; set; } = null!;
     /// <summary>
-    /// Country uses ZeroOrMany CountryTimeZones
+    /// Country uses OneOrMany CountryTimeZones
     /// </summary>
     public virtual List<CountryTimeZoneUpsertDto>? CountryTimeZones { get; set; }
     /// <summary>

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/CountryFactory.g.cs
@@ -127,45 +127,45 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         //createDto.CountryLocalNames?.ForEach(async dto =>
         //{
         //    var countryLocalName = await CountryLocalNameFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToCountryLocalNames(countryLocalName);
+        //    entity.CreateCountryLocalNames(countryLocalName);
         //});
         if(createDto.CountryLocalNames is not null)
         {
             foreach (var dto in createDto.CountryLocalNames)
             {
                 var countryLocalName = CountryLocalNameFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToCountryLocalNames(countryLocalName);
+                entity.CreateCountryLocalNames(countryLocalName);
             }
         }
         if (createDto.CountryBarCode is not null)
         {
             var countryBarCode = await CountryBarCodeFactory.CreateEntityAsync(createDto.CountryBarCode, cultureCode);
-            entity.CreateRefToCountryBarCode(countryBarCode);
+            entity.CreateCountryBarCode(countryBarCode);
         }
         //createDto.CountryTimeZones?.ForEach(async dto =>
         //{
         //    var countryTimeZone = await CountryTimeZoneFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToCountryTimeZones(countryTimeZone);
+        //    entity.CreateCountryTimeZones(countryTimeZone);
         //});
         if(createDto.CountryTimeZones is not null)
         {
             foreach (var dto in createDto.CountryTimeZones)
             {
                 var countryTimeZone = CountryTimeZoneFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToCountryTimeZones(countryTimeZone);
+                entity.CreateCountryTimeZones(countryTimeZone);
             }
         }
         //createDto.Holidays?.ForEach(async dto =>
         //{
         //    var holiday = await HolidayFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToHolidays(holiday);
+        //    entity.CreateHolidays(holiday);
         //});
         if(createDto.Holidays is not null)
         {
             foreach (var dto in createDto.Holidays)
             {
                 var holiday = HolidayFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToHolidays(holiday);
+                entity.CreateHolidays(holiday);
             }
         }        
         return await Task.FromResult(entity);
@@ -367,7 +367,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         if(!updateDto.CountryLocalNames.Any())
         { 
             _repository.DeleteOwned(entity.CountryLocalNames);
-			entity.DeleteAllRefToCountryLocalNames();
+			entity.DeleteAllCountryLocalNames();
         }
 		else
 		{
@@ -394,7 +394,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 			}
             _repository.DeleteOwned<ClientApi.Domain.CountryLocalName>(
                 entity.CountryLocalNames.Where(x => !updatedCountryLocalNames.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToCountryLocalNames(updatedCountryLocalNames);
+			entity.UpdateCountryLocalNames(updatedCountryLocalNames);
 		}
 	}
 
@@ -404,14 +404,14 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         {
             if(entity.CountryBarCode is not null) 
                 _repository.DeleteOwned(entity.CountryBarCode);
-            entity.DeleteAllRefToCountryBarCode();
+            entity.DeleteAllCountryBarCode();
         }
 		else
 		{
             if(entity.CountryBarCode is not null)
                 await CountryBarCodeFactory.UpdateEntityAsync(entity.CountryBarCode, updateDto.CountryBarCode, cultureCode);
             else
-			    entity.CreateRefToCountryBarCode(await CountryBarCodeFactory.CreateEntityAsync(updateDto.CountryBarCode, cultureCode));
+			    entity.CreateCountryBarCode(await CountryBarCodeFactory.CreateEntityAsync(updateDto.CountryBarCode, cultureCode));
         }
 	}
 
@@ -423,7 +423,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         if(!updateDto.CountryTimeZones.Any())
         { 
             _repository.DeleteOwned(entity.CountryTimeZones);
-			entity.DeleteAllRefToCountryTimeZones();
+			entity.DeleteAllCountryTimeZones();
         }
 		else
 		{
@@ -450,7 +450,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 			}
             _repository.DeleteOwned<ClientApi.Domain.CountryTimeZone>(
                 entity.CountryTimeZones.Where(x => !updatedCountryTimeZones.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToCountryTimeZones(updatedCountryTimeZones);
+			entity.UpdateCountryTimeZones(updatedCountryTimeZones);
 		}
 	}
 
@@ -462,7 +462,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
         if(!updateDto.Holidays.Any())
         { 
             _repository.DeleteOwned(entity.Holidays);
-			entity.DeleteAllRefToHolidays();
+			entity.DeleteAllHolidays();
         }
 		else
 		{
@@ -489,7 +489,7 @@ internal abstract class CountryFactoryBase : IEntityFactory<CountryEntity, Count
 			}
             _repository.DeleteOwned<ClientApi.Domain.Holiday>(
                 entity.Holidays.Where(x => !updatedHolidays.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToHolidays(updatedHolidays);
+			entity.UpdateHolidays(updatedHolidays);
 		}
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/PersonFactory.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/PersonFactory.g.cs
@@ -104,7 +104,7 @@ internal abstract class PersonFactoryBase : IEntityFactory<PersonEntity, PersonC
         if (createDto.UserContactSelection is not null)
         {
             var userContactSelection = await UserContactSelectionFactory.CreateEntityAsync(createDto.UserContactSelection, cultureCode);
-            entity.CreateRefToUserContactSelection(userContactSelection);
+            entity.CreateUserContactSelection(userContactSelection);
         }        
         return await Task.FromResult(entity);
     }
@@ -170,14 +170,14 @@ internal abstract class PersonFactoryBase : IEntityFactory<PersonEntity, PersonC
         {
             if(entity.UserContactSelection is not null) 
                 _repository.DeleteOwned(entity.UserContactSelection);
-            entity.DeleteAllRefToUserContactSelection();
+            entity.DeleteAllUserContactSelection();
         }
 		else
 		{
             if(entity.UserContactSelection is not null)
                 await UserContactSelectionFactory.UpdateEntityAsync(entity.UserContactSelection, updateDto.UserContactSelection, cultureCode);
             else
-			    entity.CreateRefToUserContactSelection(await UserContactSelectionFactory.CreateEntityAsync(updateDto.UserContactSelection, cultureCode));
+			    entity.CreateUserContactSelection(await UserContactSelectionFactory.CreateEntityAsync(updateDto.UserContactSelection, cultureCode));
         }
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreFactory.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/StoreFactory.g.cs
@@ -106,7 +106,7 @@ internal abstract class StoreFactoryBase : IEntityFactory<StoreEntity, StoreCrea
         if (createDto.EmailAddress is not null)
         {
             var emailAddress = await EmailAddressFactory.CreateEntityAsync(createDto.EmailAddress, cultureCode);
-            entity.CreateRefToEmailAddress(emailAddress);
+            entity.CreateEmailAddress(emailAddress);
         }        
         return await Task.FromResult(entity);
     }
@@ -201,14 +201,14 @@ internal abstract class StoreFactoryBase : IEntityFactory<StoreEntity, StoreCrea
         {
             if(entity.EmailAddress is not null) 
                 _repository.DeleteOwned(entity.EmailAddress);
-            entity.DeleteAllRefToEmailAddress();
+            entity.DeleteAllEmailAddress();
         }
 		else
 		{
             if(entity.EmailAddress is not null)
                 await EmailAddressFactory.UpdateEntityAsync(entity.EmailAddress, updateDto.EmailAddress, cultureCode);
             else
-			    entity.CreateRefToEmailAddress(await EmailAddressFactory.CreateEntityAsync(updateDto.EmailAddress, cultureCode));
+			    entity.CreateEmailAddress(await EmailAddressFactory.CreateEntityAsync(updateDto.EmailAddress, cultureCode));
         }
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TenantFactory.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TenantFactory.g.cs
@@ -104,20 +104,20 @@ internal abstract class TenantFactoryBase : IEntityFactory<TenantEntity, TenantC
         //createDto.TenantBrands?.ForEach(async dto =>
         //{
         //    var tenantBrand = await TenantBrandFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToTenantBrands(tenantBrand);
+        //    entity.CreateTenantBrands(tenantBrand);
         //});
         if(createDto.TenantBrands is not null)
         {
             foreach (var dto in createDto.TenantBrands)
             {
                 var tenantBrand = TenantBrandFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToTenantBrands(tenantBrand);
+                entity.CreateTenantBrands(tenantBrand);
             }
         }
         if (createDto.TenantContact is not null)
         {
             var tenantContact = await TenantContactFactory.CreateEntityAsync(createDto.TenantContact, cultureCode);
-            entity.CreateRefToTenantContact(tenantContact);
+            entity.CreateTenantContact(tenantContact);
         }        
         return await Task.FromResult(entity);
     }
@@ -178,7 +178,7 @@ internal abstract class TenantFactoryBase : IEntityFactory<TenantEntity, TenantC
         if(!updateDto.TenantBrands.Any())
         { 
             _repository.DeleteOwned(entity.TenantBrands);
-			entity.DeleteAllRefToTenantBrands();
+			entity.DeleteAllTenantBrands();
         }
 		else
 		{
@@ -205,7 +205,7 @@ internal abstract class TenantFactoryBase : IEntityFactory<TenantEntity, TenantC
 			}
             _repository.DeleteOwned<ClientApi.Domain.TenantBrand>(
                 entity.TenantBrands.Where(x => !updatedTenantBrands.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToTenantBrands(updatedTenantBrands);
+			entity.UpdateTenantBrands(updatedTenantBrands);
 		}
 	}
 
@@ -215,14 +215,14 @@ internal abstract class TenantFactoryBase : IEntityFactory<TenantEntity, TenantC
         {
             if(entity.TenantContact is not null) 
                 _repository.DeleteOwned(entity.TenantContact);
-            entity.DeleteAllRefToTenantContact();
+            entity.DeleteAllTenantContact();
         }
 		else
 		{
             if(entity.TenantContact is not null)
                 await TenantContactFactory.UpdateEntityAsync(entity.TenantContact, updateDto.TenantContact, cultureCode);
             else
-			    entity.CreateRefToTenantContact(await TenantContactFactory.CreateEntityAsync(updateDto.TenantContact, cultureCode));
+			    entity.CreateTenantContact(await TenantContactFactory.CreateEntityAsync(updateDto.TenantContact, cultureCode));
         }
 	}
 }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
@@ -285,7 +285,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     }﻿
 
     /// <summary>
-    /// Country uses ZeroOrMany CountryTimeZones
+    /// Country uses OneOrMany CountryTimeZones
     /// </summary>
     public virtual List<CountryTimeZone> CountryTimeZones { get; private set; } = new();
     
@@ -302,6 +302,8 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void UpdateRefToCountryTimeZones(List<CountryTimeZone> relatedCountryTimeZone)
     {
+        if(!relatedCountryTimeZone.HasAtLeastOneItem())
+            throw new RelationshipDeletionException($"The relationship cannot be updated.");
         CountryTimeZones.Clear();
         CountryTimeZones.AddRange(relatedCountryTimeZone);
     }
@@ -311,6 +313,8 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void DeleteRefToCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
     {
+        if(CountryTimeZones.HasExactlyOneItem())
+            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
         CountryTimeZones.Remove(relatedCountryTimeZone);
     }
     
@@ -319,6 +323,8 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void DeleteAllRefToCountryTimeZones()
     {
+        if(CountryTimeZones.HasExactlyOneItem())
+            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
         CountryTimeZones.Clear();
     }﻿
 

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
@@ -225,7 +225,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new CountryLocalName entity.
     /// </summary>
-    public virtual void CreateRefToCountryLocalNames(CountryLocalName relatedCountryLocalName)
+    public virtual void CreateCountryLocalNames(CountryLocalName relatedCountryLocalName)
     {
         CountryLocalNames.Add(relatedCountryLocalName);
     }
@@ -233,7 +233,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned CountryLocalName entities.
     /// </summary>
-    public virtual void UpdateRefToCountryLocalNames(List<CountryLocalName> relatedCountryLocalName)
+    public virtual void UpdateCountryLocalNames(List<CountryLocalName> relatedCountryLocalName)
     {
         CountryLocalNames.Clear();
         CountryLocalNames.AddRange(relatedCountryLocalName);
@@ -242,7 +242,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned CountryLocalName entity.
     /// </summary>
-    public virtual void DeleteRefToCountryLocalNames(CountryLocalName relatedCountryLocalName)
+    public virtual void DeleteCountryLocalNames(CountryLocalName relatedCountryLocalName)
     {
         CountryLocalNames.Remove(relatedCountryLocalName);
     }
@@ -250,7 +250,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned CountryLocalName entities.
     /// </summary>
-    public virtual void DeleteAllRefToCountryLocalNames()
+    public virtual void DeleteAllCountryLocalNames()
     {
         CountryLocalNames.Clear();
     }﻿
@@ -263,7 +263,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new CountryBarCode entity.
     /// </summary>
-    public virtual void CreateRefToCountryBarCode(CountryBarCode relatedCountryBarCode)
+    public virtual void CreateCountryBarCode(CountryBarCode relatedCountryBarCode)
     {
         CountryBarCode = relatedCountryBarCode;
     }
@@ -271,7 +271,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned CountryBarCode entity.
     /// </summary>
-    public virtual void DeleteRefToCountryBarCode(CountryBarCode relatedCountryBarCode)
+    public virtual void DeleteCountryBarCode(CountryBarCode relatedCountryBarCode)
     {
         CountryBarCode = null;
     }
@@ -279,7 +279,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned CountryBarCode entities.
     /// </summary>
-    public virtual void DeleteAllRefToCountryBarCode()
+    public virtual void DeleteAllCountryBarCode()
     {
         CountryBarCode = null;
     }﻿
@@ -292,7 +292,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new CountryTimeZone entity.
     /// </summary>
-    public virtual void CreateRefToCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
+    public virtual void CreateCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
     {
         CountryTimeZones.Add(relatedCountryTimeZone);
     }
@@ -300,7 +300,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned CountryTimeZone entities.
     /// </summary>
-    public virtual void UpdateRefToCountryTimeZones(List<CountryTimeZone> relatedCountryTimeZone)
+    public virtual void UpdateCountryTimeZones(List<CountryTimeZone> relatedCountryTimeZone)
     {
         if(!relatedCountryTimeZone.HasAtLeastOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be updated.");
@@ -311,7 +311,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned CountryTimeZone entity.
     /// </summary>
-    public virtual void DeleteRefToCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
+    public virtual void DeleteCountryTimeZones(CountryTimeZone relatedCountryTimeZone)
     {
         if(CountryTimeZones.HasExactlyOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be deleted.");
@@ -321,7 +321,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned CountryTimeZone entities.
     /// </summary>
-    public virtual void DeleteAllRefToCountryTimeZones()
+    public virtual void DeleteAllCountryTimeZones()
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }﻿
@@ -334,7 +334,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new Holiday entity.
     /// </summary>
-    public virtual void CreateRefToHolidays(Holiday relatedHoliday)
+    public virtual void CreateHolidays(Holiday relatedHoliday)
     {
         Holidays.Add(relatedHoliday);
     }
@@ -342,7 +342,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Updates all owned Holiday entities.
     /// </summary>
-    public virtual void UpdateRefToHolidays(List<Holiday> relatedHoliday)
+    public virtual void UpdateHolidays(List<Holiday> relatedHoliday)
     {
         Holidays.Clear();
         Holidays.AddRange(relatedHoliday);
@@ -351,7 +351,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned Holiday entity.
     /// </summary>
-    public virtual void DeleteRefToHolidays(Holiday relatedHoliday)
+    public virtual void DeleteHolidays(Holiday relatedHoliday)
     {
         Holidays.Remove(relatedHoliday);
     }
@@ -359,7 +359,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned Holiday entities.
     /// </summary>
-    public virtual void DeleteAllRefToHolidays()
+    public virtual void DeleteAllHolidays()
     {
         Holidays.Clear();
     }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Country.g.cs
@@ -323,9 +323,7 @@ public abstract partial class CountryBase : AuditableEntityBase, IEtag
     /// </summary>
     public virtual void DeleteAllRefToCountryTimeZones()
     {
-        if(CountryTimeZones.HasExactlyOneItem())
-            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-        CountryTimeZones.Clear();
+        throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }﻿
 
     /// <summary>

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Person.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Person.g.cs
@@ -131,7 +131,7 @@ public abstract partial class PersonBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new UserContactSelection entity.
     /// </summary>
-    public virtual void CreateRefToUserContactSelection(UserContactSelection relatedUserContactSelection)
+    public virtual void CreateUserContactSelection(UserContactSelection relatedUserContactSelection)
     {
         UserContactSelection = relatedUserContactSelection;
     }
@@ -139,7 +139,7 @@ public abstract partial class PersonBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned UserContactSelection entity.
     /// </summary>
-    public virtual void DeleteRefToUserContactSelection(UserContactSelection relatedUserContactSelection)
+    public virtual void DeleteUserContactSelection(UserContactSelection relatedUserContactSelection)
     {
         UserContactSelection = null;
     }
@@ -147,7 +147,7 @@ public abstract partial class PersonBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned UserContactSelection entities.
     /// </summary>
-    public virtual void DeleteAllRefToUserContactSelection()
+    public virtual void DeleteAllUserContactSelection()
     {
         UserContactSelection = null;
     }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Store.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Store.g.cs
@@ -284,7 +284,7 @@ public abstract partial class StoreBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Creates a new EmailAddress entity.
     /// </summary>
-    public virtual void CreateRefToEmailAddress(EmailAddress relatedEmailAddress)
+    public virtual void CreateEmailAddress(EmailAddress relatedEmailAddress)
     {
         EmailAddress = relatedEmailAddress;
     }
@@ -292,7 +292,7 @@ public abstract partial class StoreBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes owned EmailAddress entity.
     /// </summary>
-    public virtual void DeleteRefToEmailAddress(EmailAddress relatedEmailAddress)
+    public virtual void DeleteEmailAddress(EmailAddress relatedEmailAddress)
     {
         EmailAddress = null;
     }
@@ -300,7 +300,7 @@ public abstract partial class StoreBase : AuditableEntityBase, IEtag
     /// <summary>
     /// Deletes all owned EmailAddress entities.
     /// </summary>
-    public virtual void DeleteAllRefToEmailAddress()
+    public virtual void DeleteAllEmailAddress()
     {
         EmailAddress = null;
     }

--- a/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Tenant.g.cs
+++ b/tests/Nox.ClientApi.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/Tenant.g.cs
@@ -147,7 +147,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Creates a new TenantBrand entity.
     /// </summary>
-    public virtual void CreateRefToTenantBrands(TenantBrand relatedTenantBrand)
+    public virtual void CreateTenantBrands(TenantBrand relatedTenantBrand)
     {
         TenantBrands.Add(relatedTenantBrand);
     }
@@ -155,7 +155,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Updates all owned TenantBrand entities.
     /// </summary>
-    public virtual void UpdateRefToTenantBrands(List<TenantBrand> relatedTenantBrand)
+    public virtual void UpdateTenantBrands(List<TenantBrand> relatedTenantBrand)
     {
         TenantBrands.Clear();
         TenantBrands.AddRange(relatedTenantBrand);
@@ -164,7 +164,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Deletes owned TenantBrand entity.
     /// </summary>
-    public virtual void DeleteRefToTenantBrands(TenantBrand relatedTenantBrand)
+    public virtual void DeleteTenantBrands(TenantBrand relatedTenantBrand)
     {
         TenantBrands.Remove(relatedTenantBrand);
     }
@@ -172,7 +172,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Deletes all owned TenantBrand entities.
     /// </summary>
-    public virtual void DeleteAllRefToTenantBrands()
+    public virtual void DeleteAllTenantBrands()
     {
         TenantBrands.Clear();
     }﻿
@@ -185,7 +185,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Creates a new TenantContact entity.
     /// </summary>
-    public virtual void CreateRefToTenantContact(TenantContact relatedTenantContact)
+    public virtual void CreateTenantContact(TenantContact relatedTenantContact)
     {
         TenantContact = relatedTenantContact;
     }
@@ -193,7 +193,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Deletes owned TenantContact entity.
     /// </summary>
-    public virtual void DeleteRefToTenantContact(TenantContact relatedTenantContact)
+    public virtual void DeleteTenantContact(TenantContact relatedTenantContact)
     {
         TenantContact = null;
     }
@@ -201,7 +201,7 @@ public abstract partial class TenantBase : EntityBase, IEtag
     /// <summary>
     /// Deletes all owned TenantContact entities.
     /// </summary>
-    public virtual void DeleteAllRefToTenantContact()
+    public virtual void DeleteAllTenantContact()
     {
         TenantContact = null;
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelat
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToSecEntityOwnedRelExactlyOne(entity);
+		parentEntity.CreateSecEntityOwnedRelExactlyOne(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRela
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
+		parentEntity.CreateSecEntityOwnedRelOneOrManies(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRel
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
+		parentEntity.CreateSecEntityOwnedRelZeroOrManies(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/CreateSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
@@ -60,7 +60,7 @@ internal abstract class CreateSecondTestEntityOwnedRelationshipZeroOrOneForTestE
 		}
 
 		var entity = await RntityFactory.CreateEntityAsync(request.EntityDto, request.CultureCode);
-		parentEntity.CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(entity);
+		parentEntity.CreateSecondTestEntityOwnedRelationshipZeroOrOne(entity);
 		parentEntity.Etag = request.Etag.HasValue ? request.Etag.Value : System.Guid.Empty;
 
 		await OnCompletedAsync(request, entity);

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteSecEntityOwnedRelExactlyOneForTestEntityOwnedRelati
 			throw new EntityNotFoundException("TestEntityOwnedRelationshipExactlyOne.SecEntityOwnedRelExactlyOne",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToSecEntityOwnedRelExactlyOne(entity);
+		parentEntity.DeleteSecEntityOwnedRelExactlyOne(entity);
 		
 		
 		

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/DeleteSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
@@ -58,7 +58,7 @@ internal partial class DeleteSecondTestEntityOwnedRelationshipZeroOrOneForTestEn
 			throw new EntityNotFoundException("TestEntityOwnedRelationshipZeroOrOne.SecondTestEntityOwnedRelationshipZeroOrOne",  String.Empty);
 		}
 
-		parentEntity.DeleteRefToSecondTestEntityOwnedRelationshipZeroOrOne(entity);
+		parentEntity.DeleteSecondTestEntityOwnedRelationshipZeroOrOne(entity);
 		
 		
 		

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelationshipExactlyOneCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateSecEntityOwnedRelExactlyOneForTestEntityOwnedRelati
 	private async Task<SecEntityOwnedRelExactlyOneEntity> CreateEntityAsync(SecEntityOwnedRelExactlyOneUpsertDto upsertDto, TestEntityOwnedRelationshipExactlyOneEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToSecEntityOwnedRelExactlyOne(entity);
+		parent.CreateSecEntityOwnedRelExactlyOne(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
@@ -67,20 +67,23 @@ internal partial class UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelat
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
 			}
 			else
 			{
 				var ownedId = Dto.SecEntityOwnedRelOneOrManyMetadata.CreateId(entityDto.Id.NonNullValue<System.String>());
 				entity = parentEntity.SecEntityOwnedRelOneOrManies.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+					parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToSecEntityOwnedRelOneOrManies(entity);
+				}
 			}
 
-			parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelationshipOneOrManyCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelat
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
+				parentEntity.CreateSecEntityOwnedRelOneOrManies(entity);
 			}
 			else
 			{
@@ -76,7 +76,7 @@ internal partial class UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelat
 				if (entity is null)
 				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-					parentEntity.CreateRefToSecEntityOwnedRelOneOrManies(entity);
+					parentEntity.CreateSecEntityOwnedRelOneOrManies(entity);
 				}
 				else
 				{
@@ -98,7 +98,7 @@ internal partial class UpdateSecEntityOwnedRelOneOrManiesForTestEntityOwnedRelat
 	private async Task<SecEntityOwnedRelOneOrManyEntity> CreateEntityAsync(SecEntityOwnedRelOneOrManyUpsertDto upsertDto, TestEntityOwnedRelationshipOneOrManyEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToSecEntityOwnedRelOneOrManies(entity);
+		parent.CreateSecEntityOwnedRelOneOrManies(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
@@ -67,20 +67,23 @@ internal partial class UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRela
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+				parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
 			}
 			else
 			{
 				var ownedId = Dto.SecEntityOwnedRelZeroOrManyMetadata.CreateId(entityDto.Id.NonNullValue<System.String>());
 				entity = parentEntity.SecEntityOwnedRelZeroOrManies.SingleOrDefault(x => x.Id == ownedId);
 				if (entity is null)
+				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
+					parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
+				}
 				else
+				{
 					await _entityFactory.UpdateEntityAsync(entity, entityDto, request.CultureCode);
-
-				parentEntity.DeleteRefToSecEntityOwnedRelZeroOrManies(entity);
+				}
 			}
 
-			parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
 			entities.Add(entity);
 		}
 

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRelationshipZeroOrManyCommand.g.cs
@@ -67,7 +67,7 @@ internal partial class UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRela
 			if(entityDto.Id is null)
 			{
 				entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-				parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
+				parentEntity.CreateSecEntityOwnedRelZeroOrManies(entity);
 			}
 			else
 			{
@@ -76,7 +76,7 @@ internal partial class UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRela
 				if (entity is null)
 				{
 					entity = await CreateEntityAsync(entityDto, parentEntity, request.CultureCode);
-					parentEntity.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
+					parentEntity.CreateSecEntityOwnedRelZeroOrManies(entity);
 				}
 				else
 				{
@@ -98,7 +98,7 @@ internal partial class UpdateSecEntityOwnedRelZeroOrManiesForTestEntityOwnedRela
 	private async Task<SecEntityOwnedRelZeroOrManyEntity> CreateEntityAsync(SecEntityOwnedRelZeroOrManyUpsertDto upsertDto, TestEntityOwnedRelationshipZeroOrManyEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToSecEntityOwnedRelZeroOrManies(entity);
+		parent.CreateSecEntityOwnedRelZeroOrManies(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Commands/UpdateSecondTestEntityOwnedRelationshipZeroOrOneForTestEntityOwnedRelationshipZeroOrOneCommand.g.cs
@@ -77,7 +77,7 @@ internal partial class UpdateSecondTestEntityOwnedRelationshipZeroOrOneForTestEn
 	private async Task<SecondTestEntityOwnedRelationshipZeroOrOneEntity> CreateEntityAsync(SecondTestEntityOwnedRelationshipZeroOrOneUpsertDto upsertDto, TestEntityOwnedRelationshipZeroOrOneEntity parent, Nox.Types.CultureCode cultureCode)
 	{
 		var entity = await _entityFactory.CreateEntityAsync(upsertDto, cultureCode);
-		parent.CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(entity);
+		parent.CreateSecondTestEntityOwnedRelationshipZeroOrOne(entity);
 		return entity;
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipExactlyOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipExactlyOneFactory.g.cs
@@ -98,7 +98,7 @@ internal abstract class TestEntityOwnedRelationshipExactlyOneFactoryBase : IEnti
         if (createDto.SecEntityOwnedRelExactlyOne is not null)
         {
             var secEntityOwnedRelExactlyOne = await SecEntityOwnedRelExactlyOneFactory.CreateEntityAsync(createDto.SecEntityOwnedRelExactlyOne, cultureCode);
-            entity.CreateRefToSecEntityOwnedRelExactlyOne(secEntityOwnedRelExactlyOne);
+            entity.CreateSecEntityOwnedRelExactlyOne(secEntityOwnedRelExactlyOne);
         }        
         return await Task.FromResult(entity);
     }
@@ -137,14 +137,14 @@ internal abstract class TestEntityOwnedRelationshipExactlyOneFactoryBase : IEnti
         {
             if(entity.SecEntityOwnedRelExactlyOne is not null) 
                 _repository.DeleteOwned(entity.SecEntityOwnedRelExactlyOne);
-            entity.DeleteAllRefToSecEntityOwnedRelExactlyOne();
+            entity.DeleteAllSecEntityOwnedRelExactlyOne();
         }
 		else
 		{
             if(entity.SecEntityOwnedRelExactlyOne is not null)
                 await SecEntityOwnedRelExactlyOneFactory.UpdateEntityAsync(entity.SecEntityOwnedRelExactlyOne, updateDto.SecEntityOwnedRelExactlyOne, cultureCode);
             else
-			    entity.CreateRefToSecEntityOwnedRelExactlyOne(await SecEntityOwnedRelExactlyOneFactory.CreateEntityAsync(updateDto.SecEntityOwnedRelExactlyOne, cultureCode));
+			    entity.CreateSecEntityOwnedRelExactlyOne(await SecEntityOwnedRelExactlyOneFactory.CreateEntityAsync(updateDto.SecEntityOwnedRelExactlyOne, cultureCode));
         }
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipOneOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipOneOrManyFactory.g.cs
@@ -98,14 +98,14 @@ internal abstract class TestEntityOwnedRelationshipOneOrManyFactoryBase : IEntit
         //createDto.SecEntityOwnedRelOneOrManies?.ForEach(async dto =>
         //{
         //    var secEntityOwnedRelOneOrMany = await SecEntityOwnedRelOneOrManyFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToSecEntityOwnedRelOneOrManies(secEntityOwnedRelOneOrMany);
+        //    entity.CreateSecEntityOwnedRelOneOrManies(secEntityOwnedRelOneOrMany);
         //});
         if(createDto.SecEntityOwnedRelOneOrManies is not null)
         {
             foreach (var dto in createDto.SecEntityOwnedRelOneOrManies)
             {
                 var secEntityOwnedRelOneOrMany = SecEntityOwnedRelOneOrManyFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToSecEntityOwnedRelOneOrManies(secEntityOwnedRelOneOrMany);
+                entity.CreateSecEntityOwnedRelOneOrManies(secEntityOwnedRelOneOrMany);
             }
         }        
         return await Task.FromResult(entity);
@@ -147,7 +147,7 @@ internal abstract class TestEntityOwnedRelationshipOneOrManyFactoryBase : IEntit
         if(!updateDto.SecEntityOwnedRelOneOrManies.Any())
         { 
             _repository.DeleteOwned(entity.SecEntityOwnedRelOneOrManies);
-			entity.DeleteAllRefToSecEntityOwnedRelOneOrManies();
+			entity.DeleteAllSecEntityOwnedRelOneOrManies();
         }
 		else
 		{
@@ -174,7 +174,7 @@ internal abstract class TestEntityOwnedRelationshipOneOrManyFactoryBase : IEntit
 			}
             _repository.DeleteOwned<TestWebApp.Domain.SecEntityOwnedRelOneOrMany>(
                 entity.SecEntityOwnedRelOneOrManies.Where(x => !updatedSecEntityOwnedRelOneOrManies.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToSecEntityOwnedRelOneOrManies(updatedSecEntityOwnedRelOneOrManies);
+			entity.UpdateSecEntityOwnedRelOneOrManies(updatedSecEntityOwnedRelOneOrManies);
 		}
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrManyFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrManyFactory.g.cs
@@ -98,14 +98,14 @@ internal abstract class TestEntityOwnedRelationshipZeroOrManyFactoryBase : IEnti
         //createDto.SecEntityOwnedRelZeroOrManies?.ForEach(async dto =>
         //{
         //    var secEntityOwnedRelZeroOrMany = await SecEntityOwnedRelZeroOrManyFactory.CreateEntityAsync(dto, cultureCode);
-        //    entity.CreateRefToSecEntityOwnedRelZeroOrManies(secEntityOwnedRelZeroOrMany);
+        //    entity.CreateSecEntityOwnedRelZeroOrManies(secEntityOwnedRelZeroOrMany);
         //});
         if(createDto.SecEntityOwnedRelZeroOrManies is not null)
         {
             foreach (var dto in createDto.SecEntityOwnedRelZeroOrManies)
             {
                 var secEntityOwnedRelZeroOrMany = SecEntityOwnedRelZeroOrManyFactory.CreateEntityAsync(dto, cultureCode).Result;
-                entity.CreateRefToSecEntityOwnedRelZeroOrManies(secEntityOwnedRelZeroOrMany);
+                entity.CreateSecEntityOwnedRelZeroOrManies(secEntityOwnedRelZeroOrMany);
             }
         }        
         return await Task.FromResult(entity);
@@ -147,7 +147,7 @@ internal abstract class TestEntityOwnedRelationshipZeroOrManyFactoryBase : IEnti
         if(!updateDto.SecEntityOwnedRelZeroOrManies.Any())
         { 
             _repository.DeleteOwned(entity.SecEntityOwnedRelZeroOrManies);
-			entity.DeleteAllRefToSecEntityOwnedRelZeroOrManies();
+			entity.DeleteAllSecEntityOwnedRelZeroOrManies();
         }
 		else
 		{
@@ -174,7 +174,7 @@ internal abstract class TestEntityOwnedRelationshipZeroOrManyFactoryBase : IEnti
 			}
             _repository.DeleteOwned<TestWebApp.Domain.SecEntityOwnedRelZeroOrMany>(
                 entity.SecEntityOwnedRelZeroOrManies.Where(x => !updatedSecEntityOwnedRelZeroOrManies.Exists(upd => upd.Id == x.Id)).ToList());
-			entity.UpdateRefToSecEntityOwnedRelZeroOrManies(updatedSecEntityOwnedRelZeroOrManies);
+			entity.UpdateSecEntityOwnedRelZeroOrManies(updatedSecEntityOwnedRelZeroOrManies);
 		}
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrOneFactory.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Application.Factories/TestEntityOwnedRelationshipZeroOrOneFactory.g.cs
@@ -98,7 +98,7 @@ internal abstract class TestEntityOwnedRelationshipZeroOrOneFactoryBase : IEntit
         if (createDto.SecondTestEntityOwnedRelationshipZeroOrOne is not null)
         {
             var secondTestEntityOwnedRelationshipZeroOrOne = await SecondTestEntityOwnedRelationshipZeroOrOneFactory.CreateEntityAsync(createDto.SecondTestEntityOwnedRelationshipZeroOrOne, cultureCode);
-            entity.CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(secondTestEntityOwnedRelationshipZeroOrOne);
+            entity.CreateSecondTestEntityOwnedRelationshipZeroOrOne(secondTestEntityOwnedRelationshipZeroOrOne);
         }        
         return await Task.FromResult(entity);
     }
@@ -137,14 +137,14 @@ internal abstract class TestEntityOwnedRelationshipZeroOrOneFactoryBase : IEntit
         {
             if(entity.SecondTestEntityOwnedRelationshipZeroOrOne is not null) 
                 _repository.DeleteOwned(entity.SecondTestEntityOwnedRelationshipZeroOrOne);
-            entity.DeleteAllRefToSecondTestEntityOwnedRelationshipZeroOrOne();
+            entity.DeleteAllSecondTestEntityOwnedRelationshipZeroOrOne();
         }
 		else
 		{
             if(entity.SecondTestEntityOwnedRelationshipZeroOrOne is not null)
                 await SecondTestEntityOwnedRelationshipZeroOrOneFactory.UpdateEntityAsync(entity.SecondTestEntityOwnedRelationshipZeroOrOne, updateDto.SecondTestEntityOwnedRelationshipZeroOrOne, cultureCode);
             else
-			    entity.CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(await SecondTestEntityOwnedRelationshipZeroOrOneFactory.CreateEntityAsync(updateDto.SecondTestEntityOwnedRelationshipZeroOrOne, cultureCode));
+			    entity.CreateSecondTestEntityOwnedRelationshipZeroOrOne(await SecondTestEntityOwnedRelationshipZeroOrOneFactory.CreateEntityAsync(updateDto.SecondTestEntityOwnedRelationshipZeroOrOne, cultureCode));
         }
 	}
 }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipExactlyOne.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipExactlyOne.g.cs
@@ -99,7 +99,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOneBase : Audita
     /// <summary>
     /// Creates a new SecEntityOwnedRelExactlyOne entity.
     /// </summary>
-    public virtual void CreateRefToSecEntityOwnedRelExactlyOne(SecEntityOwnedRelExactlyOne relatedSecEntityOwnedRelExactlyOne)
+    public virtual void CreateSecEntityOwnedRelExactlyOne(SecEntityOwnedRelExactlyOne relatedSecEntityOwnedRelExactlyOne)
     {
         SecEntityOwnedRelExactlyOne = relatedSecEntityOwnedRelExactlyOne;
     }
@@ -107,7 +107,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOneBase : Audita
     /// <summary>
     /// Deletes owned SecEntityOwnedRelExactlyOne entity.
     /// </summary>
-    public virtual void DeleteRefToSecEntityOwnedRelExactlyOne(SecEntityOwnedRelExactlyOne relatedSecEntityOwnedRelExactlyOne)
+    public virtual void DeleteSecEntityOwnedRelExactlyOne(SecEntityOwnedRelExactlyOne relatedSecEntityOwnedRelExactlyOne)
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }
@@ -115,7 +115,7 @@ public abstract partial class TestEntityOwnedRelationshipExactlyOneBase : Audita
     /// <summary>
     /// Deletes all owned SecEntityOwnedRelExactlyOne entities.
     /// </summary>
-    public virtual void DeleteAllRefToSecEntityOwnedRelExactlyOne()
+    public virtual void DeleteAllSecEntityOwnedRelExactlyOne()
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipOneOrMany.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipOneOrMany.g.cs
@@ -130,9 +130,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManyBase : Auditab
     /// </summary>
     public virtual void DeleteAllRefToSecEntityOwnedRelOneOrManies()
     {
-        if(SecEntityOwnedRelOneOrManies.HasExactlyOneItem())
-            throw new RelationshipDeletionException($"The relationship cannot be deleted.");
-        SecEntityOwnedRelOneOrManies.Clear();
+        throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }
 
     

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipOneOrMany.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipOneOrMany.g.cs
@@ -99,7 +99,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManyBase : Auditab
     /// <summary>
     /// Creates a new SecEntityOwnedRelOneOrMany entity.
     /// </summary>
-    public virtual void CreateRefToSecEntityOwnedRelOneOrManies(SecEntityOwnedRelOneOrMany relatedSecEntityOwnedRelOneOrMany)
+    public virtual void CreateSecEntityOwnedRelOneOrManies(SecEntityOwnedRelOneOrMany relatedSecEntityOwnedRelOneOrMany)
     {
         SecEntityOwnedRelOneOrManies.Add(relatedSecEntityOwnedRelOneOrMany);
     }
@@ -107,7 +107,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManyBase : Auditab
     /// <summary>
     /// Updates all owned SecEntityOwnedRelOneOrMany entities.
     /// </summary>
-    public virtual void UpdateRefToSecEntityOwnedRelOneOrManies(List<SecEntityOwnedRelOneOrMany> relatedSecEntityOwnedRelOneOrMany)
+    public virtual void UpdateSecEntityOwnedRelOneOrManies(List<SecEntityOwnedRelOneOrMany> relatedSecEntityOwnedRelOneOrMany)
     {
         if(!relatedSecEntityOwnedRelOneOrMany.HasAtLeastOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be updated.");
@@ -118,7 +118,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManyBase : Auditab
     /// <summary>
     /// Deletes owned SecEntityOwnedRelOneOrMany entity.
     /// </summary>
-    public virtual void DeleteRefToSecEntityOwnedRelOneOrManies(SecEntityOwnedRelOneOrMany relatedSecEntityOwnedRelOneOrMany)
+    public virtual void DeleteSecEntityOwnedRelOneOrManies(SecEntityOwnedRelOneOrMany relatedSecEntityOwnedRelOneOrMany)
     {
         if(SecEntityOwnedRelOneOrManies.HasExactlyOneItem())
             throw new RelationshipDeletionException($"The relationship cannot be deleted.");
@@ -128,7 +128,7 @@ public abstract partial class TestEntityOwnedRelationshipOneOrManyBase : Auditab
     /// <summary>
     /// Deletes all owned SecEntityOwnedRelOneOrMany entities.
     /// </summary>
-    public virtual void DeleteAllRefToSecEntityOwnedRelOneOrManies()
+    public virtual void DeleteAllSecEntityOwnedRelOneOrManies()
     {
         throw new RelationshipDeletionException($"The relationship cannot be deleted.");
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipZeroOrMany.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipZeroOrMany.g.cs
@@ -99,7 +99,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManyBase : Audita
     /// <summary>
     /// Creates a new SecEntityOwnedRelZeroOrMany entity.
     /// </summary>
-    public virtual void CreateRefToSecEntityOwnedRelZeroOrManies(SecEntityOwnedRelZeroOrMany relatedSecEntityOwnedRelZeroOrMany)
+    public virtual void CreateSecEntityOwnedRelZeroOrManies(SecEntityOwnedRelZeroOrMany relatedSecEntityOwnedRelZeroOrMany)
     {
         SecEntityOwnedRelZeroOrManies.Add(relatedSecEntityOwnedRelZeroOrMany);
     }
@@ -107,7 +107,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManyBase : Audita
     /// <summary>
     /// Updates all owned SecEntityOwnedRelZeroOrMany entities.
     /// </summary>
-    public virtual void UpdateRefToSecEntityOwnedRelZeroOrManies(List<SecEntityOwnedRelZeroOrMany> relatedSecEntityOwnedRelZeroOrMany)
+    public virtual void UpdateSecEntityOwnedRelZeroOrManies(List<SecEntityOwnedRelZeroOrMany> relatedSecEntityOwnedRelZeroOrMany)
     {
         SecEntityOwnedRelZeroOrManies.Clear();
         SecEntityOwnedRelZeroOrManies.AddRange(relatedSecEntityOwnedRelZeroOrMany);
@@ -116,7 +116,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManyBase : Audita
     /// <summary>
     /// Deletes owned SecEntityOwnedRelZeroOrMany entity.
     /// </summary>
-    public virtual void DeleteRefToSecEntityOwnedRelZeroOrManies(SecEntityOwnedRelZeroOrMany relatedSecEntityOwnedRelZeroOrMany)
+    public virtual void DeleteSecEntityOwnedRelZeroOrManies(SecEntityOwnedRelZeroOrMany relatedSecEntityOwnedRelZeroOrMany)
     {
         SecEntityOwnedRelZeroOrManies.Remove(relatedSecEntityOwnedRelZeroOrMany);
     }
@@ -124,7 +124,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrManyBase : Audita
     /// <summary>
     /// Deletes all owned SecEntityOwnedRelZeroOrMany entities.
     /// </summary>
-    public virtual void DeleteAllRefToSecEntityOwnedRelZeroOrManies()
+    public virtual void DeleteAllSecEntityOwnedRelZeroOrManies()
     {
         SecEntityOwnedRelZeroOrManies.Clear();
     }

--- a/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipZeroOrOne.g.cs
+++ b/tests/Nox.Integration.Tests/Generated/Nox.Generator/Nox.Generator.NoxCodeGenerator/Domain/TestEntityOwnedRelationshipZeroOrOne.g.cs
@@ -99,7 +99,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOneBase : Auditab
     /// <summary>
     /// Creates a new SecondTestEntityOwnedRelationshipZeroOrOne entity.
     /// </summary>
-    public virtual void CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(SecondTestEntityOwnedRelationshipZeroOrOne relatedSecondTestEntityOwnedRelationshipZeroOrOne)
+    public virtual void CreateSecondTestEntityOwnedRelationshipZeroOrOne(SecondTestEntityOwnedRelationshipZeroOrOne relatedSecondTestEntityOwnedRelationshipZeroOrOne)
     {
         SecondTestEntityOwnedRelationshipZeroOrOne = relatedSecondTestEntityOwnedRelationshipZeroOrOne;
     }
@@ -107,7 +107,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOneBase : Auditab
     /// <summary>
     /// Deletes owned SecondTestEntityOwnedRelationshipZeroOrOne entity.
     /// </summary>
-    public virtual void DeleteRefToSecondTestEntityOwnedRelationshipZeroOrOne(SecondTestEntityOwnedRelationshipZeroOrOne relatedSecondTestEntityOwnedRelationshipZeroOrOne)
+    public virtual void DeleteSecondTestEntityOwnedRelationshipZeroOrOne(SecondTestEntityOwnedRelationshipZeroOrOne relatedSecondTestEntityOwnedRelationshipZeroOrOne)
     {
         SecondTestEntityOwnedRelationshipZeroOrOne = null;
     }
@@ -115,7 +115,7 @@ public abstract partial class TestEntityOwnedRelationshipZeroOrOneBase : Auditab
     /// <summary>
     /// Deletes all owned SecondTestEntityOwnedRelationshipZeroOrOne entities.
     /// </summary>
-    public virtual void DeleteAllRefToSecondTestEntityOwnedRelationshipZeroOrOne()
+    public virtual void DeleteAllSecondTestEntityOwnedRelationshipZeroOrOne()
     {
         SecondTestEntityOwnedRelationshipZeroOrOne = null;
     }

--- a/tests/Nox.Integration.Tests/Tests/Database/DatabaseTests.cs
+++ b/tests/Nox.Integration.Tests/Tests/Database/DatabaseTests.cs
@@ -788,7 +788,7 @@ public class DatabaseTests
             TextTestField2 = Text.From(textId2),
         };
 
-        newItem.CreateRefToSecEntityOwnedRelExactlyOne(newItem2);
+        newItem.CreateSecEntityOwnedRelExactlyOne(newItem2);
         DataContext.TestEntityOwnedRelationshipExactlyOnes.Add(newItem);
         DataContext.SaveChanges();
 
@@ -818,7 +818,7 @@ public class DatabaseTests
             TextTestField2 = Text.From(textId2),
         };
 
-        newItem.CreateRefToSecondTestEntityOwnedRelationshipZeroOrOne(newItem2);
+        newItem.CreateSecondTestEntityOwnedRelationshipZeroOrOne(newItem2);
         DataContext.TestEntityOwnedRelationshipZeroOrOnes.Add(newItem);
         DataContext.SaveChanges();
 


### PR DESCRIPTION
1. Fixed issue when deleting all owned entities where relationship type is oneOrMany -> deletion should not be possible.
2. Renamed methods for handling owned entitites (Create, Update, Delete) -> removed RefTo from name.